### PR TITLE
Fixed vertical centering of previous/next buttons (Issue #136)

### DIFF
--- a/components/Chapter/PageNavigator.js
+++ b/components/Chapter/PageNavigator.js
@@ -10,14 +10,14 @@ function PageNavigator({ pageNumber, pageCount, route }) {
     <div className="relative z-10">
       {previousPage >= 1 && (
         <Link href={`/${route}/${previousPage}`} passHref>
-          <a className="rounded-full h-10 w-10 fixed z-neg top-1/2 md:top-1/3 left-3 hover:brightness-90 hover:cursor-pointer flex justify-center items-center  bg-white dark:bg-dark-100 dark:hover:bg-dark-bg dark:border-gray-600 border">
+          <a className="rounded-full h-10 w-10 fixed z-neg top-1/2 left-3 hover:brightness-90 hover:cursor-pointer flex justify-center items-center  bg-white dark:bg-dark-100 dark:hover:bg-dark-bg dark:border-gray-600 border">
             <SvgChevronLeft className="dark:text-gray-50" />
           </a>
         </Link>
       )}
       {nextPage <= pageCount && (
         <Link href={`/${route}/${nextPage}`} passHref>
-          <a className="rounded-full h-10 w-10 fixed z-neg top-1/2 md:top-1/3 right-3 hover:brightness-90 hover:cursor-pointer flex justify-center items-center  bg-white dark:bg-dark-100 dark:hover:bg-dark-bg dark:border-gray-600 border">
+          <a className="rounded-full h-10 w-10 fixed z-neg top-1/2 right-3 hover:brightness-90 hover:cursor-pointer flex justify-center items-center  bg-white dark:bg-dark-100 dark:hover:bg-dark-bg dark:border-gray-600 border">
             <SvgChevronRight className="dark:text-gray-50" />
           </a>
         </Link>


### PR DESCRIPTION
This PR addresses issue #136, regarding Previous/Next buttons to be centered vertically based on the height of the screen. 
``` 
Modified PageNavigator.js
Removed the md:top-1/3 breakpoint from the buttons (Line No. 13 &  20)
```