### PR TITLE
Add continuous navigation to PageNavigator

### DIFF
--- a/src/app/chapter/[chapterNumber]/(chapter)/[[...locale]]/ChapterPage.tsx
+++ b/src/app/chapter/[chapterNumber]/(chapter)/[[...locale]]/ChapterPage.tsx
@@ -56,11 +56,7 @@ export default function ChapterPage({
         <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 lg:top-12 lg:w-min" />
       </div>
 
-      <PageNavigator
-        pageNumber={chapter_number}
-        pageCount={18}
-        route="chapter"
-      />
+      <PageNavigator currentChapter={chapter_number} />
 
       <section className="relative mx-auto max-w-5xl px-4 py-24 text-center font-inter sm:px-6">
         <h3

--- a/src/app/chapter/[chapterNumber]/verse/[verseNumber]/[[...locale]]/page.tsx
+++ b/src/app/chapter/[chapterNumber]/verse/[verseNumber]/[[...locale]]/page.tsx
@@ -14,27 +14,13 @@ export const dynamic = "force-dynamic";
 type Props = {
   params: {
     chapterNumber: string;
-    verseNumber: [string, string?];
+    verseNumber: string;
     locale: string[];
   };
 };
 
-// export async function generateStaticParams() {
-//   const data = await getVerseId();
-
-//   return data.gita_verses.map(({ chapter_number, verse_number }) => ({
-//     params: {
-//       chapterNumber: chapter_number.toString(),
-//       verseNumber: verse_number.toString(),
-//     },
-//   }));
-// }
-
 export async function generateMetadata({
-  params: {
-    verseNumber: [verseNumber],
-    chapterNumber,
-  },
+  params: { verseNumber, chapterNumber },
 }: Props): Promise<Metadata> {
   return {
     title: `Bhagavad Gita Chapter ${chapterNumber} Verse ${verseNumber} - BhagavadGita.io`,
@@ -77,10 +63,7 @@ export async function generateMetadata({
 }
 
 const Verse = async ({ params }: Props) => {
-  const {
-    chapterNumber,
-    verseNumber: [verseNumber],
-  } = params;
+  const { chapterNumber, verseNumber } = params;
 
   const locale = paramsToLocale(params);
 
@@ -91,8 +74,8 @@ const Verse = async ({ params }: Props) => {
   });
 
   const verseData = await getVerseData(
-    chapterNumber,
-    verseNumber,
+    Number(chapterNumber),
+    Number(verseNumber),
     languageSettings.commentaryAuthor.id,
     languageSettings.translationAuthor.id,
   );

--- a/src/components/Chapter/PageNavigator.tsx
+++ b/src/components/Chapter/PageNavigator.tsx
@@ -1,69 +1,41 @@
 import LinkWithLocale from "components/LinkWithLocale";
 
 import { SvgChevronLeft, SvgChevronRight } from "../svgs";
+import { getNextPageHref, getPrevPageHref } from "./functions";
 
 interface Props {
-  pageNumber: number;
-  pageCount: number;
-  route: string;
-  maxVerseCount?: number;
-  verseNumber?: number;
+  currentChapter: number;
+  currentVerse?: number;
+  totalVerses?: number;
+  prevChapterTotalVerses?: number;
 }
 
 function PageNavigator({
-  pageNumber,
-  pageCount,
-  route,
-  maxVerseCount = 0,
-  verseNumber = 0,
+  currentChapter,
+  currentVerse,
+  totalVerses,
+  prevChapterTotalVerses,
 }: Props) {
-  const staticVerse = verseNumber;
-  let currentVerse = verseNumber;
-  const nextPage =
-    route === "verse"
-      ? verseNumber >= maxVerseCount
-        ? pageNumber + 1
-        : pageNumber
-      : pageNumber + 1;
-  const previousPage =
-    route === "verse"
-      ? verseNumber === 1
-        ? pageNumber - 1
-        : pageNumber
-      : pageNumber - 1;
-  const nextVerse =
-    verseNumber >= maxVerseCount ? (verseNumber = 1) : verseNumber + 1;
-
-  const previousVerse = currentVerse >= 2 ? currentVerse - 1 : verseNumber;
-
   return (
     <div className="relative z-10">
-      {previousPage >= 1 && (
-        <LinkWithLocale
-          prefetch={false}
-          href={
-            route === "verse" && currentVerse > 1
-              ? `/chapter/${previousPage}/${route}/${previousVerse}`
-              : `/chapter/${previousPage}`
-          }
-          className="fixed left-3 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border bg-white  hover:cursor-pointer hover:brightness-90 dark:border-gray-600 dark:bg-dark-100 dark:hover:bg-dark-bg"
-        >
-          <SvgChevronLeft className="dark:text-gray-50" />
-        </LinkWithLocale>
-      )}
-      {nextPage <= pageCount && (
-        <LinkWithLocale
-          prefetch={false}
-          href={
-            route === "verse" && maxVerseCount > staticVerse
-              ? `/chapter/${nextPage}/${route}/${nextVerse}`
-              : `/chapter/${nextPage}`
-          }
-          className="fixed right-3 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border bg-white  hover:cursor-pointer hover:brightness-90 dark:border-gray-600 dark:bg-dark-100 dark:hover:bg-dark-bg"
-        >
-          <SvgChevronRight className="dark:text-gray-50" />
-        </LinkWithLocale>
-      )}
+      <LinkWithLocale
+        prefetch={false}
+        href={getPrevPageHref(
+          currentChapter,
+          currentVerse,
+          prevChapterTotalVerses,
+        )}
+        className="fixed left-3 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border bg-white  hover:cursor-pointer hover:brightness-90 dark:border-gray-600 dark:bg-dark-100 dark:hover:bg-dark-bg"
+      >
+        <SvgChevronLeft className="dark:text-gray-50" />
+      </LinkWithLocale>
+      <LinkWithLocale
+        prefetch={false}
+        href={getNextPageHref(currentChapter, currentVerse, totalVerses)}
+        className="fixed right-3 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border bg-white  hover:cursor-pointer hover:brightness-90 dark:border-gray-600 dark:bg-dark-100 dark:hover:bg-dark-bg"
+      >
+        <SvgChevronRight className="dark:text-gray-50" />
+      </LinkWithLocale>
     </div>
   );
 }

--- a/src/components/Chapter/functions.ts
+++ b/src/components/Chapter/functions.ts
@@ -1,0 +1,39 @@
+const totalChapters = 18;
+
+export const getPrevPageHref = (
+  currentChapter: number,
+  currentVerse?: number,
+  prevChapterTotalVerses?: number,
+) => {
+  const prevChapterAvailable = currentChapter > 1;
+  const prevChapterNumber = prevChapterAvailable
+    ? currentChapter - 1
+    : totalChapters;
+  if (!currentVerse) {
+    return `/chapter/${prevChapterNumber}`;
+  }
+
+  const prevVerseAvailable = currentVerse > 1;
+  if (!prevVerseAvailable) {
+    return `/chapter/${prevChapterNumber}/verse/${prevChapterTotalVerses}`;
+  }
+  return `/chapter/${currentChapter}/verse/${currentVerse - 1}`;
+};
+
+export const getNextPageHref = (
+  currentChapter: number,
+  currentVerse?: number,
+  totalVerses?: number,
+) => {
+  const nextChapterAvailable = currentChapter < totalChapters;
+  const nextChapterNumber = nextChapterAvailable ? currentChapter + 1 : 1;
+  if (!currentVerse) {
+    return `/chapter/${nextChapterNumber}`;
+  }
+
+  const nextVerseAvailable = currentVerse < totalVerses;
+  if (!nextVerseAvailable) {
+    return `/chapter/${nextChapterNumber}/verse/1`;
+  }
+  return `/chapter/${currentChapter}/verse/${currentVerse + 1}`;
+};

--- a/src/components/Verse/index.tsx
+++ b/src/components/Verse/index.tsx
@@ -22,6 +22,7 @@ type Props = {
 const Verse = ({
   verse: {
     gita_chapter,
+    prev_chapter_verses_count,
     verse_number,
     chapter_number,
     text,
@@ -53,11 +54,10 @@ const Verse = ({
       />
 
       <PageNavigator
-        pageCount={18}
-        route="verse"
-        maxVerseCount={gita_chapter.verses_count}
-        verseNumber={verse_number}
-        pageNumber={chapter_number}
+        currentChapter={chapter_number}
+        currentVerse={verse_number}
+        totalVerses={gita_chapter.verses_count}
+        prevChapterTotalVerses={prev_chapter_verses_count}
       />
 
       <section className="mx-auto max-w-5xl px-4 py-16 text-center font-inter sm:px-6">

--- a/src/hooks/useAdvancedSettings.ts
+++ b/src/hooks/useAdvancedSettings.ts
@@ -34,7 +34,6 @@ function useAdvancedSettings(locale: Locale) {
   });
 
   useEffect(() => {
-    console.error(locale);
     setAdvancedSettings(getAdvancedSettings(locale));
   }, [locale]);
 

--- a/src/lib/getDailyVerse.ts
+++ b/src/lib/getDailyVerse.ts
@@ -22,7 +22,7 @@ const getWhereGitaAuthor = (
   };
 };
 
-export const getDailyVerse = (locale: Locale) =>
+export const getDailyVerse = (locale: Locale): Promise<GitaVerse> =>
   resolved(() => {
     const gitaVerse =
       query.gita_verses_by_pk({
@@ -58,5 +58,6 @@ export const getDailyVerse = (locale: Locale) =>
       gita_chapter: {
         verses_count: gitaVerse.gita_chapter?.verses_count || 0,
       },
+      prev_chapter_verses_count: 0,
     };
   });

--- a/src/lib/getVerseData.ts
+++ b/src/lib/getVerseData.ts
@@ -13,11 +13,11 @@ export const getVerseId = () =>
   );
 
 export const getVerseData = (
-  chapterNumber,
-  verseNumber,
-  commentariesAuthorId,
-  translationsAuthorId,
-) =>
+  chapterNumber: number,
+  verseNumber: number,
+  commentariesAuthorId: number,
+  translationsAuthorId: number,
+): Promise<GitaVerse> =>
   resolved(() => {
     const [gitaVerse] = query.gita_verses({
       where: {
@@ -26,6 +26,14 @@ export const getVerseData = (
         },
         verse_number: {
           _eq: verseNumber,
+        },
+      },
+    });
+
+    const [prevChapter] = query.gita_chapters({
+      where: {
+        chapter_number: {
+          _eq: chapterNumber - 1 || 18,
         },
       },
     });
@@ -42,8 +50,13 @@ export const getVerseData = (
       verse_number: gitaVerse.verse_number!,
       word_meanings: gitaVerse.word_meanings!,
       gita_chapter: {
-        verses_count: gitaVerse.gita_chapter?.verses_count || 0,
+        verses_count: gitaVerse.gita_chapter
+          .gita_verses_aggregate()
+          .aggregate.count(),
       },
+      prev_chapter_verses_count: prevChapter
+        .gita_verses_aggregate()
+        .aggregate.count(),
       gita_commentaries: gitaVerse
         .gita_commentaries({
           where: {

--- a/src/redux/reducers/settings.ts
+++ b/src/redux/reducers/settings.ts
@@ -1,6 +1,6 @@
 import * as t from "../Types";
 
-const initialVerse = {
+const initialVerse: GitaVerse = {
   verse_number: 1,
   chapter_number: 1,
   id: 1,
@@ -10,6 +10,7 @@ const initialVerse = {
   gita_chapter: {
     verses_count: 1,
   },
+  prev_chapter_verses_count: 0,
   gita_commentaries: [{ description: "" }],
   gita_translations: [{ description: "" }],
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,6 +29,7 @@ interface GitaVerse {
   gita_chapter: {
     verses_count: number;
   };
+  prev_chapter_verses_count: number;
   gita_commentaries: GitaLanguage[];
   gita_translations: GitaLanguage[];
 }


### PR DESCRIPTION
Introduce `getPrevPageHref()` and `getNextPageHref()` in `PageNavigator`
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced navigation between pages with the introduction of `getPrevPageHref()` and `getNextPageHref()` functions in the `PageNavigator` component. These functions provide seamless navigation across chapters, even when transitioning from the first verse of a chapter to the last verse of the previous chapter, or vice versa.
- Refactor: Simplified the `generateMetadata()` function by accepting a single string for the `verseNumber` parameter instead of an array.
- Refactor: Improved type safety in `getVerseData()` function by adding explicit type annotations.
- New Feature: Added `prev_chapter_verses_count` property to the `Verse` component and GitaVerse interface, enhancing the accuracy of page navigation calculations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->