### PR TITLE
fix : remove hasura admin secret

### DIFF
--- a/gqty.config.cjs
+++ b/gqty.config.cjs
@@ -5,8 +5,7 @@ const fs = require("fs");
 require("dotenv").config({ path: ".env.development.local" });
 
 if (
-  !process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT ||
-  !process.env.NEXT_PUBLIC_HASURA_ADMIN_SECRET
+  !process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT 
 ) {
   throw new Error("Some required env vars not found in file");
 }
@@ -16,9 +15,6 @@ const config = {
   scalarTypes: { DateTime: "string" },
   introspection: {
     endpoint: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT,
-    headers: {
-      "x-hasura-admin-secret": process.env.NEXT_PUBLIC_HASURA_ADMIN_SECRET,
-    },
   },
   destination: "./src/gqty-client/index.ts",
   enumsAsConst: true,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/gqty-client/index.ts
+++ b/src/gqty-client/index.ts
@@ -21,7 +21,6 @@ const queryFetcher: QueryFetcher = async function (
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-hasura-admin-secret": process.env.NEXT_PUBLIC_HASURA_ADMIN_SECRET!,
     },
     body: JSON.stringify({
       query,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Removed the requirement for the `NEXT_PUBLIC_HASURA_ADMIN_SECRET` environment variable and the corresponding header in the `introspection` object from gqty.config.cjs. This simplifies the process of making GraphQL requests.
- Refactor: Removed the `x-hasura-admin-secret` header from the HTTP request in the `queryFetcher` function in src/gqty-client/index.ts, further streamlining the GraphQL request process.
- Chore: Cleaned up unused references in next-env.d.ts, improving code cleanliness and maintainability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->