### PR TITLE
fix verse of the day

### DIFF
--- a/src/components/Home/VerseOfDay.tsx
+++ b/src/components/Home/VerseOfDay.tsx
@@ -20,7 +20,7 @@ const VerseOfDay = async (props: LocaleAndTranslations) => {
             <h2 className="divider line one-line mb-4 px-4 font-bold text-my-orange">
               {translate("Verse of the day")} -{" "}
               {translate("BG <%= verseNumber %>", {
-                verseNumber: `${dailyVerse?.chapter_number}`,
+                verseNumber: `${dailyVerse?.chapter_number}.${dailyVerse?.verse_number}`,
               })}
             </h2>
             <p className="text-lg">


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Enhancement: Updated the `VerseOfDay` component in the Home section. Now, it displays both the chapter number and verse number for the daily verse, providing a more accurate reference for users.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->