### PR TITLE
Switch to `getPrevPageHref()` in AudioPlayer

### DIFF
--- a/src/components/Headers/AudioPlayer.tsx
+++ b/src/components/Headers/AudioPlayer.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useRef, useState } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import Image from "next/image";
 
+import { getNextPageHref, getPrevPageHref } from "components/Chapter/functions";
 import LinkWithLocale from "components/LinkWithLocale";
 
 interface Props {
@@ -164,7 +165,11 @@ function AudioPlayer({
 
                 <div className="mt-4 flex justify-between px-4">
                   <LinkWithLocale
-                    href={`/chapter/${currentVerse?.chapter_number}/verse/${prevId}`}
+                    href={getPrevPageHref(
+                      currentVerse.chapter_number,
+                      currentVerse.verse_number,
+                      currentVerse.prev_chapter_verses_count,
+                    )}
                     className={`hover:cursor-pointer  hover:brightness-90 dark:hover:brightness-50 ${
                       prevId <= 0 ? "pointer-events-none" : ""
                     }`}
@@ -187,7 +192,11 @@ function AudioPlayer({
                     alt="play or pause icon"
                   />
                   <LinkWithLocale
-                    href={`/chapter/${currentVerse?.chapter_number}/verse/${nextId}`}
+                    href={getNextPageHref(
+                      currentVerse.chapter_number,
+                      currentVerse.verse_number,
+                      currentVerse.gita_chapter.verses_count,
+                    )}
                     className={`hover:cursor-pointer  hover:brightness-90 dark:hover:brightness-50 ${
                       nextId > 701 ? "pointer-events-none" : ""
                     }`}

--- a/src/components/Headers/IndexHeader.tsx
+++ b/src/components/Headers/IndexHeader.tsx
@@ -150,8 +150,8 @@ export default function IndexHeader({ locale, translate }: Props) {
   return (
     <div className="fixed top-0 z-50 w-full">
       <Popover className="relative bg-white font-inter dark:bg-dark-100">
-        <div className="mx-auto max-w-7xl px-4 xl:px-0">
-          <div className="flex items-center justify-between  py-6 md:space-x-10">
+        <div className="mx-auto max-w-7xl px-6">
+          <div className="flex items-center justify-between py-6 md:space-x-10">
             <div className="flex justify-start lg:w-0 lg:flex-1">
               <LinkWithLocale
                 href="/"

--- a/src/components/Headers/PageHeader.tsx
+++ b/src/components/Headers/PageHeader.tsx
@@ -495,7 +495,11 @@ function PageHeader(props: Props) {
       ) : null}
       {playerIsOpen && (
         <Suspense
-          fallback={<div className="absolute">{translate("Loading")}</div>}
+          fallback={
+            <div className="absolute animate-pulse p-3 text-gray-300">
+              {translate("Loading")}
+            </div>
+          }
         >
           <AudioPlayer
             currentVerse={currentVerse}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated `AudioPlayer` component to dynamically generate URLs for previous and next pages based on the current verse's chapter number, verse number, and related counts. This change enhances the flexibility of the audio player navigation.
- Style: Modified the styling and layout of the `IndexHeader` and `PageHeader` components for improved user interface aesthetics.
- New Feature: Introduced an animated pulse effect as a loading indicator in the `PageHeader` component, enhancing the user experience during content loading.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->