### PR TITLE
Remove grouping in splitIntoParagraphs() regex

### DIFF
--- a/src/utils/splitIntoParagraphs.ts
+++ b/src/utils/splitIntoParagraphs.ts
@@ -2,7 +2,7 @@ export default function splitIntoParagraphs(
   textData: GitaLanguage[] | undefined,
 ): string[] | undefined {
   if (textData) {
-    const sentences = textData[0].description.split(/(?<=[.!?])\s+/);
+    const sentences = textData[0].description.split(" ");
 
     const paragraphs: string[] = [];
     let currentParagraph = "";


### PR DESCRIPTION
Safari doesn't support lookbehind
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `splitIntoParagraphs` utility function in `src/utils/splitIntoParagraphs.ts`. The regular expression used for splitting text into paragraphs has been simplified, which may improve performance and readability. This change should not affect the functionality from a user's perspective.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->