### PR TITLE
Make safer parsed values in `getVerseData()`

### DIFF
--- a/src/app/chapter/[chapterNumber]/(chapter)/[[...locale]]/page.tsx
+++ b/src/app/chapter/[chapterNumber]/(chapter)/[[...locale]]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { chapterNumber } = params;
   const chapterData = await getChapterData(
     paramsToLocale(params),
-    parseInt(chapterNumber),
+    Number(chapterNumber) || 1,
   );
   if (!chapterData) {
     return {};
@@ -85,7 +85,7 @@ export default async function Chapter({ params }: Props) {
 
   const chapterData = await getChapterData(
     locale,
-    parseInt(chapterNumber),
+    Number(chapterNumber) || 1,
     languageSettings.translationAuthor.id,
   );
 

--- a/src/app/chapter/[chapterNumber]/verse/[verseNumber]/[[...locale]]/page.tsx
+++ b/src/app/chapter/[chapterNumber]/verse/[verseNumber]/[[...locale]]/page.tsx
@@ -74,8 +74,8 @@ const Verse = async ({ params }: Props) => {
   });
 
   const verseData = await getVerseData(
-    Number(chapterNumber),
-    Number(verseNumber),
+    Number(chapterNumber) || 1,
+    Number(verseNumber) || 1,
     languageSettings.commentaryAuthor.id,
     languageSettings.translationAuthor.id,
   );

--- a/src/gqty-client/index.ts
+++ b/src/gqty-client/index.ts
@@ -17,7 +17,10 @@ const queryFetcher: QueryFetcher = async function (
   variables,
   fetchOptions,
 ) {
-  const response = await fetch(process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT!, {
+  if (!process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT) {
+    throw new Error("NEXT_PUBLIC_GRAPHQL_ENDPOINT should be present");
+  }
+  const response = await fetch(process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Improved handling of `chapterNumber` and `verseNumber` parameters in the Chapter and Verse components. Now, if these parameters are not valid numbers, they will default to 1, ensuring consistent behavior.
- Refactor: Enhanced safety checks in the GraphQL client setup. The application now verifies the presence of the `NEXT_PUBLIC_GRAPHQL_ENDPOINT` environment variable before making a request, preventing potential errors due to missing configuration.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->