### PR TITLE
:memo: fix: Overflow of quotes in footer on mobile view

### DIFF
--- a/src/components/Quotes/Quote.tsx
+++ b/src/components/Quotes/Quote.tsx
@@ -13,27 +13,31 @@ export default function Quote({ quoteNumber, quote, translate }: Props) {
   const styles = useMyStyles();
   return (
     <>
-      <div className="absolute inset-x-0 top-[5%] mx-auto max-w-5xl text-center font-inter">
-        <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 lg:top-12 lg:w-min" />
-      </div>
+      <div className="flex flex-col h-screen">
+        <div className="flex-1 relative mx-auto max-w-5xl px-4 text-center font-inter sm:px-6 sm:py-28 overflow-hidden">
+          <div className="absolute inset-x-0 top-[5%] mx-auto max-w-5xl text-center font-inter">
+            <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 lg:top-12 lg:w-min" />
+          </div>
 
-      <div className="xs:py-24 relative mx-auto max-w-5xl px-4 text-center font-inter sm:px-6 sm:py-28">
-        <h2
-          className={classNames(
-            "font-medium uppercase text-my-orange",
-            styles.fontSize.subHeading2,
-          )}
-        >
-          {translate("Quote")} {quoteNumber}
-        </h2>
-        <p
-          className={classNames(
-            "dark:text-white max-w-2xl md:text-2xl mt-3 mx-auto sm:text-xl text-center text-lg",
-            styles.lineHeight,
-          )}
-        >
-          {quote}
-        </p>
+          <div className="xs:py-24 relative mx-auto max-w-5xl px-4 text-center font-inter sm:px-6 sm:py-28">
+            <h2
+              className={classNames(
+                "font-medium uppercase text-my-orange",
+                styles.fontSize.subHeading2,
+              )}
+            >
+              {translate("Quote")} {quoteNumber}
+            </h2>
+            <p
+              className={classNames(
+                "dark:text-white max-w-2xl md:text-2xl mt-3 mx-auto sm:text-xl text-center text-lg",
+                styles.lineHeight,
+              )}
+            >
+              {quote}
+            </p>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/src/components/Quotes/Quote.tsx
+++ b/src/components/Quotes/Quote.tsx
@@ -28,7 +28,7 @@ export default function Quote({ quoteNumber, quote, translate }: Props) {
         </h2>
         <p
           className={classNames(
-            "mx-auto mt-3 max-w-2xl text-center text-2xl dark:text-white",
+            "dark:text-white max-w-2xl md:text-2xl mt-3 mx-auto sm:text-xl text-center text-lg",
             styles.lineHeight,
           )}
         >


### PR DESCRIPTION
## What?
This PR addresses the issue of quote overflow #216 in the footer when the website is viewed on small devices.
## Why?
The overflow of quotes in the footer on small devices created a poor user experience, as it made the content difficult to read and interact with. This problem needed to be resolved to ensure that our website is accessible and functional across all devices.

## Screenshots 
Before 
![image](https://github.com/gita/gita-frontend-v2/assets/126372969/81f11a50-a624-41a0-93b3-68c59e1a83df)






After
![image](https://github.com/gita/gita-frontend-v2/assets/126372969/c6cea216-9aa6-4f5c-a6d8-77bbd61d2502)

