### PR TITLE
added custom 404 page [fixes #210]

### DIFF
--- a/src/app/chapter/[chapterNumber]/(chapter)/[[...locale]]/page.tsx
+++ b/src/app/chapter/[chapterNumber]/(chapter)/[[...locale]]/page.tsx
@@ -102,11 +102,18 @@ export default async function Chapter({ params }: Props) {
     languageSettings.translationAuthor.id,
   );
 
-  if (!chapterData) {
-    return <NotFound hint={`Chapter ${chapterNumber} not found`} />;
-  }
-
   const translations = await getTranslations(locale);
+
+  if (!chapterData) {
+    return (
+      <NotFound
+        translations={translations}
+        locale={locale}
+        hint={chapterNumber}
+        isChapter={true}
+      />
+    );
+  }
 
   return (
     <>

--- a/src/app/chapter/[chapterNumber]/verse/[verseNumber]/[[...locale]]/page.tsx
+++ b/src/app/chapter/[chapterNumber]/verse/[verseNumber]/[[...locale]]/page.tsx
@@ -121,11 +121,18 @@ const Verse = async ({ params }: Props) => {
     languageSettings.translationAuthor.id,
   );
 
-  if (!verseData) {
-    return <NotFound hint={`Verse ${verseNumber} not found`} />;
-  }
-
   const translations = await getTranslations(locale);
+
+  if (!verseData) {
+    return (
+      <NotFound
+        translations={translations}
+        locale={locale}
+        hint={verseNumber}
+        isVerse={true}
+      />
+    );
+  }
 
   return (
     <article>

--- a/src/app/verse-of-the-day/[[...locale]]/page.tsx
+++ b/src/app/verse-of-the-day/[[...locale]]/page.tsx
@@ -62,7 +62,13 @@ const Page = async ({ params }: ParamsWithLocale) => {
   const dailyVerse = await getDailyVerse(locale);
 
   if (!dailyVerse) {
-    return <NotFound hint="Daily verse not found" />;
+    return (
+      <NotFound
+        translations={await getTranslations(locale)}
+        locale={locale}
+        hint="Daily verse not found"
+      />
+    );
   }
 
   return (

--- a/src/components/NotFound/index.tsx
+++ b/src/components/NotFound/index.tsx
@@ -1,11 +1,50 @@
+import Image from "next/image";
+
+import LinkWithLocale from "components/LinkWithLocale";
+import { getTranslate } from "shared/translate";
+
 type Props = {
   hint?: string;
-};
+  isChapter?: boolean;
+  isVerse?: boolean;
+} & LocaleAndTranslations;
 
 function NotFound(props: Props) {
   const { hint } = props;
+  const { translations, locale, isChapter, isVerse } = props;
 
-  return <h1 className="p-10 text-center">{hint || "Not found"}</h1>;
+  const translate = getTranslate(translations, locale);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Image
+        src={"/quotes-bg.png"}
+        alt="BG Not Found Banner Image"
+        layout="fill"
+        objectFit="cover"
+        objectPosition="center"
+      />
+      <div className="p-2 text-center drop-shadow-card">
+        <h1 className="mb-4 text-4xl font-bold text-my-orange ">
+          {isChapter
+            ? `${translate("Chapter")} ${hint} ${translate("Not found")}`
+            : isVerse
+            ? `${translate("Verse")} ${hint} ${translate("Not found")}`
+            : `${translate(hint || "Not found")}`}
+        </h1>
+        <p className="mb-8 text-xl text-white">
+          {" "}
+          {translate("Sorry, the page you're looking for doesn't exist")}
+        </p>
+        <LinkWithLocale
+          href={"/"}
+          className="items-center rounded-md border border-gray-300 bg-white px-6 py-3 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-my-orange focus:ring-offset-2"
+        >
+          {translate("Go Back to Home")}
+        </LinkWithLocale>
+      </div>
+    </div>
+  );
 }
 
 export default NotFound;

--- a/src/shared/translate/locales/hi.json
+++ b/src/shared/translate/locales/hi.json
@@ -86,4 +86,8 @@
   "Acknowledgements": "स्वीकृतियाँ",
   "Gita AI": "गीता एआई",
   "Bhagavad Gita AI": "Bhagavad Gita AI"
+  "Go Back to Home": "होम पेज पर वापस जाएँ",
+  "Sorry, the page you're looking for doesn't exist": "क्षमा करें, आप जिस पेज की तलाश कर रहे हैं वह मौजूद नहीं है",
+  "Daily verse not found": "दैनिक श्लोक नहीं मिला",
+  "Not found": "नहीं मिला"
 }


### PR DESCRIPTION
Have modified the custom 404 page. [Fixes #210]

Previous UI
<img width="1114" alt="Screenshot 2023-10-06 at 11 03 40 PM" src="https://github.com/gita/gita-frontend-v2/assets/69191344/33f64a6e-5d20-4ed8-adf6-067450fe8918">

<img width="1105" alt="Screenshot 2023-10-06 at 11 03 31 PM" src="https://github.com/gita/gita-frontend-v2/assets/69191344/bada5d1b-b895-4152-b312-4d35d818b4db">

New UI 


<img width="1175" alt="Screenshot 2023-10-06 at 11 03 00 PM" src="https://github.com/gita/gita-frontend-v2/assets/69191344/7dfbc37f-2efb-4d65-b4de-8006c9ee391f">
<img width="1186" alt="Screenshot 2023-10-06 at 11 03 21 PM" src="https://github.com/gita/gita-frontend-v2/assets/69191344/d80a277f-08d3-4015-a1ff-e52742b5a6f5">

Have added translation for hindi as well

<img width="1159" alt="Screenshot 2023-10-06 at 11 21 48 PM" src="https://github.com/gita/gita-frontend-v2/assets/69191344/ace7c400-c072-4c16-80e2-c146ccdc602c">

This UI renders when wrong chapter or verse is entered in URL and also in case the verse of the day is missing 