### PR TITLE
quotes mobile css fix [fixes #216]

### DIFF
--- a/src/app/bhagavad-gita-quotes/[[...locale]]/QuotesPage.tsx
+++ b/src/app/bhagavad-gita-quotes/[[...locale]]/QuotesPage.tsx
@@ -16,9 +16,9 @@ export default function QuotesPage(props: LocaleAndTranslations) {
   const [quoteIndex, setQuoteIndex] = useState(0);
 
   return (
-    <div className="mb-16">
+    <div className="">
       <QuotesBanner translate={translate} />
-      <div className="relative z-10 m-auto h-96 p-0 md:w-[90%] lg:w-[73%] xl:w-[66%]">
+      <div className="relative z-10 m-auto flex min-h-screen items-center p-0 md:w-[90%] lg:w-[73%] xl:w-[66%]">
         <QuotesNavigator
           quoteCount={quotes.length}
           quoteIndex={quoteIndex}

--- a/src/app/bhagavad-gita-quotes/[[...locale]]/QuotesPage.tsx
+++ b/src/app/bhagavad-gita-quotes/[[...locale]]/QuotesPage.tsx
@@ -18,7 +18,7 @@ export default function QuotesPage(props: LocaleAndTranslations) {
   return (
     <div className="">
       <QuotesBanner translate={translate} />
-      <div className="relative z-10 m-auto flex min-h-screen items-center p-0 md:w-[90%] lg:w-[73%] xl:w-[66%]">
+      <div className="relative z-10 m-auto flex min-h-[480px] items-center p-0 md:w-[90%] lg:w-[73%] xl:w-[66%] ">
         <QuotesNavigator
           quoteCount={quotes.length}
           quoteIndex={quoteIndex}

--- a/src/components/Quotes/Quote.tsx
+++ b/src/components/Quotes/Quote.tsx
@@ -14,7 +14,7 @@ export default function Quote({ quoteNumber, quote, translate }: Props) {
   return (
     <>
       <div className="absolute inset-x-0 mx-auto text-center font-inter">
-        <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto h-full w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 md:min-w-fit lg:w-min" />
+        <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto h-full w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 md:max-w-fit lg:w-min" />
       </div>
 
       <div className="xs:py-24 relative mx-auto max-w-5xl px-4 text-center font-inter sm:px-6 sm:py-28">

--- a/src/components/Quotes/Quote.tsx
+++ b/src/components/Quotes/Quote.tsx
@@ -13,14 +13,14 @@ export default function Quote({ quoteNumber, quote, translate }: Props) {
   const styles = useMyStyles();
   return (
     <>
-      <div className="absolute inset-x-0 top-[5%] mx-auto max-w-5xl text-center font-inter">
-        <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 lg:top-12 lg:w-min" />
+      <div className="absolute inset-x-0 mx-auto text-center font-inter">
+        <SvgChapterBackground className="relative inset-x-0 bottom-0 m-auto h-full w-full rounded-full text-gray-300 text-opacity-25 dark:text-black dark:text-opacity-25 md:min-w-fit lg:w-min" />
       </div>
 
       <div className="xs:py-24 relative mx-auto max-w-5xl px-4 text-center font-inter sm:px-6 sm:py-28">
         <h2
           className={classNames(
-            "font-medium uppercase text-my-orange",
+            "font-medium uppercase text-my-orange mt-2",
             styles.fontSize.subHeading2,
           )}
         >

--- a/src/components/QuotesBanner.tsx
+++ b/src/components/QuotesBanner.tsx
@@ -10,7 +10,7 @@ export default function QuotesBanner(props: Props) {
   const { translate } = props;
 
   return (
-    <div className="relative z-10 mx-auto max-w-full xl:mx-24">
+    <div className="relative z-10 mx-auto max-w-full xl:mx-24 md:mb-5">
       <Image
         src={QuotesBannerBG}
         alt="BG Quotes Banner Image"


### PR DESCRIPTION
[Fixes #216] 
This PR resolves quotes mobile css overflow issue.

The issue was because of fixed height mentioned h-96 in quotes page file. So I have changed it to min-h-screen.
(Here I have assumed we cannot change the font size)

<img width="314" alt="Screenshot 2023-10-08 at 11 56 19 PM" src="https://github.com/gita/gita-frontend-v2/assets/69191344/41954df1-88cb-4a8d-90b9-1a62cebb6401">

Pls check the UI in different devices and suggest any changes if required @samanyougarg 
