### PR TITLE
docs: add roadmap and GTM strategy notes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,450 @@
+# Roadmap
+
+Working list for bhagavadgita.com. Each item gets its own branch and PR. Order below is
+roughly the order we'll pick things up, but it isn't fixed — pull whatever is most useful next.
+
+Status key: `todo` · `in progress` · `blocked` · `done`
+
+---
+
+## 1. Finish the .io → .com domain migration
+
+**Status:** todo
+**Branch:** `fix/domain-migration-cleanup`
+
+The domain moved from bhagavadgita.io to bhagavadgita.com, but nine references to the old
+domain are still in the codebase:
+
+- `src/app/privacy-policy/[[...locale]]/page.tsx`
+- `src/app/terms-of-service/[[...locale]]/page.tsx`
+- `src/app/copyright/[[...locale]]/page.tsx`
+- `src/components/Footers/Footer.tsx`
+
+**Important exception:** the contact address stays `contact@bhagavadgita.io`. That mailbox is
+still live on the old domain, so leave every `mailto:` and any email string alone. Only swap
+web URLs.
+
+Also worth checking while we're in here:
+
+- canonical tags, `metadataBase`, Open Graph and Twitter URLs
+- `sitemap.ts` and `robots.txt` output
+- structured data (`@id`, `url`, `sameAs`)
+- anything hardcoded in `public/app/index.html`, `manifest.json`, and the Supabase config
+- redirects in `vercel.json` — confirm .io still 301s to .com so we don't drop link equity
+
+---
+
+## 2. Rebuild the app landing page at /bhagavad-gita-app
+
+**Status:** todo
+**Branch:** `feat/app-landing-page`
+
+**URL decision:** the new page lives at `/bhagavad-gita-app`. `/app` 301s to it. The longer
+slug matches the head term we're going after, and the redirect keeps every existing link and
+whatever authority `/app` has accumulated.
+
+**This is the product landing page, not the comparison page.** The GTM notes are clear that
+these are two different intents and both should exist. This page explains our app and converts.
+A separate `/best-bhagavad-gita-apps/` page (item 8) compares multiple real apps, including
+competitors, and cannot honestly declare us the winner in every category. Don't merge them.
+Target keywords here: "Bhagavad Gita app", "Bhagavad Gita app download", "Gita AI app",
+"Bhagavad Gita app for Android", "Bhagavad Gita app for iPhone".
+
+Today `/app` is a static dump in `public/app/` — a 29KB `index.html` with jQuery, a 253KB
+stylesheet and a 72KB carousel script. The middleware skips `/app` entirely
+(`src/proxy.ts:12`), so it never touches Next.js. The page doesn't render properly and
+crawlers get nothing useful out of it.
+
+Replace it with a real Next.js route at `src/app/bhagavad-gita-app/[[...locale]]/page.tsx`.
+
+**Research first.** Before writing a line of copy, search Google for "bhagavad gita app" and
+related terms, and look at what's ranking:
+
+- how the top pages are structured (section order, what they lead with)
+- what they cover that we don't
+- what People Also Ask surfaces — those become our FAQ
+- keyword coverage: "bhagavad gita app", "best bhagavad gita app", "free bhagavad gita app",
+  "bhagavad gita app with audio", "gita app in hindi", "srimad bhagavad gita app"
+
+The `writesonic-marketing` repo has a `.env` with SERP API, Ahrefs and other keys we can use
+for the keyword and SERP research.
+
+**Design.** Use our existing brand kit, colors, typography (`docs/FONT_SYSTEM.md`) and button
+styles. We're on shadcn/ui — pull in whatever additional components the page needs rather
+than hand-rolling.
+
+**Assets.** High-resolution screenshots from the Play Store listing
+(https://play.google.com/store/apps/details?id=com.gitainitiative.bhagavadgita). The same
+screens may already exist locally in `~/Documents/Bhagavad-Gita-App/Bhagavad Gita App Screens`
+or in the `bhagavad-gita-app-2.0` repo — check there first, they'll be higher quality than
+anything scraped.
+
+**Content requirements:**
+
+- Store buttons for both Google Play and the App Store, above the fold
+- Feature sections built around what the app actually does
+- FAQ section driven by People Also Ask, with FAQPage schema
+- Real, human-sounding copy. No em dashes, no "unlock", "elevate", "seamless", "dive into",
+  no rule-of-three padding. Run it through `/humanizer` or `/stop-slop` before shipping.
+- Consider drafting with Codex (GPT 5.6) and editing down — it writes decent long-form.
+
+**Technical requirements:**
+
+- Server-rendered so both Google and LLM crawlers get full HTML with no JS execution
+- SoftwareApplication + FAQPage structured data
+- Proper title, description, canonical, OG and Twitter tags
+- Fast: `next/image` for screenshots, no jQuery, no 253KB stylesheet
+- Remove `/app` from the middleware skip list (`src/proxy.ts:12`) and delete `public/app/` once
+  the new page is live
+- Add the `/app` → `/bhagavad-gita-app` 301 in `vercel.json`, and update the internal links in
+  `Footer.tsx:98`, `ModernNav.tsx:106` and `donate/page.tsx:129`
+- Add the new URL to `sitemap.ts`
+
+---
+
+## 3. Audit indexability across the whole site
+
+**Status:** todo
+**Branch:** `fix/seo-indexability-audit`
+
+Confirm every public page is indexable by Google and readable by LLM crawlers. Specifically
+verify these are in the sitemap, not noindexed, not blocked in robots.txt, and server-rendered:
+
+- `/acknowledgements`
+- `/mahabharata-characters`
+- `/about`
+- `/bhagavad-gita-quotes`
+- `/donate`
+- `/gitagpt`
+- chapter and verse routes
+- `/verse-of-the-day`, `/verse-parallel`, `/translations`
+
+Check for each: canonical correctness, hreflang for the Hindi locale routes, real HTML in the
+initial response (view source, not devtools), and no client-only rendering of primary content.
+Then confirm coverage in Search Console and see whether GPTBot / ClaudeBot / PerplexityBot are
+allowed in robots.txt.
+
+---
+
+## 4. Fix GitaGPT rate limiting
+
+**Status:** todo
+**Branch:** `fix/gitagpt-rate-limit`
+
+Opening GitaGPT on mobile after months of no use immediately returns "daily limit reached",
+and logging in doesn't clear it. Something in the limiter is wrong — likely the counter isn't
+scoped or reset correctly, or the authenticated path still reads the anonymous IP/device key.
+
+Reproduce on mobile, trace the limit check, and fix both the anonymous reset window and the
+logged-in bypass or higher tier.
+
+---
+
+## 5. Verse of the Day emails
+
+**Status:** todo
+**Branch:** `feat/verse-of-the-day-emails`
+
+We collect name and email for a shloka-of-the-day subscription. First find out:
+
+- how many subscribers are in the Supabase table
+- whether anything is actually sending. Best guess: nothing is.
+- what email service, if any, is already wired up
+
+Then build it properly. Resend or Loops are both reasonable — pick based on what fits a daily
+send with a template plus an unsubscribe flow. Needs a scheduled job (Vercel cron), a decent
+HTML template using our brand, one-click unsubscribe, and basic delivery logging.
+
+If people have been subscribing for months with nothing sent, the first send should acknowledge
+that rather than pretend it's routine.
+
+---
+
+## 6. Smart mobile app install prompt
+
+**Status:** todo
+**Branch:** `feat/mobile-app-install-prompt`
+
+Right now the only app link on mobile is in the footer, where nobody finds it. Most of our
+users are on Android, some on iOS.
+
+Detect the platform and nudge toward the right store. What works elsewhere (Bible apps do this
+well): don't interrupt on first paint. Wait until someone has shown intent — scrolled through a
+chapter, read a few verses, come back a second time — then show a dismissible bar or sheet, and
+remember the dismissal.
+
+Requirements:
+
+- platform detection for Android vs iOS, deep link if the app is installed
+- trigger on engagement, not on arrival
+- dismissible, and stays dismissed
+- no layout shift, no CLS penalty, no impact on crawlers
+- replace the current modal, which is dated
+
+---
+
+---
+
+# GTM track
+
+Source: `notes/gtm-plan.md` and `notes/gtm-open-benchmarks.md`
+
+Headline target from the plan: **20,000 → 100,000 monthly organic visits**, plus app installs,
+repeat reading, branded search, and citations in AI answers.
+
+The thesis is that we already own the category-defining domain and rank for the head term, so
+growth comes from expanding into three search surfaces we barely touch today: problem searches
+("what does the Gita say about anxiety"), recommendation searches ("best Gita app"), and AI
+prompts. The shape of it: one strong head term, hundreds of medium-intent pages, thousands of
+verse-level entry points.
+
+Traffic split the plan is aiming for:
+
+| Cluster                   | Monthly target |
+| ------------------------- | -------------- |
+| Head terms and homepage   | 25K–35K        |
+| Chapter and verse pages   | 15K–25K        |
+| Life-guidance pages       | 20K–30K        |
+| App and comparison pages  | 5K–10K         |
+| Concepts and translations | 10K–15K        |
+| Long-tail questions       | 10K–20K        |
+
+---
+
+## 7. Life-guidance pages
+
+**Status:** todo
+**Branch:** `feat/guidance-pages`
+
+Called out in the notes as the largest untapped traffic surface, and the single biggest slice
+of the editorial budget at 30%. Roughly 20 pages under `/guidance/`: anxiety, anger, fear,
+grief, depression, overthinking, failure, career-confusion, workplace-stress, exam-stress,
+relationship-problems, family-pressure, loneliness, decision-making, life-purpose, discipline,
+leadership, jealousy, procrastination, death-and-loss.
+
+Framing matters and the notes are firm on it. Not "the Bhagavad Gita cures anxiety" — that's
+medically irresponsible. Instead "what the Bhagavad Gita teaches about responding to anxiety
+and uncertainty."
+
+Each page follows the same eight-part structure: the human problem, Krishna's relevant
+teaching, three to seven exact verses, commentary from a named source, a practical reflection,
+what the Gita doesn't claim, a prompt to explore it through Gita AI, related reading.
+
+---
+
+## 8. Recommendation and comparison pages
+
+**Status:** todo
+**Branch:** `feat/comparison-pages`
+
+Ranked #1 in the plan's own top-ten list. Pages under Layer 5: `/best-bhagavad-gita-apps/`,
+plus beginner, Hindi, Android, iPhone, free, with-audio, with-commentary and with-AI variants,
+then `/best-bhagavad-gita-websites/`, `/best-bhagavad-gita-translations/`,
+`/best-bhagavad-gita-commentaries/`.
+
+The credibility rule runs through all of them: we cannot win every category. The plan's own
+draft table hands "best video experience" to Bhagavad Gita For All and "best for ISKCON
+readers" to Bhagavad-gita As It Is. Several rows are still marked "based on real testing" —
+those need actual testing before they're filled in.
+
+Every comparison page carries: tested date, reviewer name, devices tested, app version, store
+rating and review count, pricing, ads or subscriptions, offline capability, languages,
+commentary tradition, audio, search, AI features, privacy, pros and cons, screenshots,
+ownership disclosure, update history.
+
+SrimadGita is the closest competitor here and has this whole layer built already. The notes'
+verdict: don't imitate the format, build the trustworthy version of it. Also worth noting that
+SrimadGita's claimed ratings and feature lists need independent verification before we treat
+any of it as fact.
+
+---
+
+## 9. Trust and methodology pages
+
+**Status:** todo
+**Branch:** `feat/editorial-standards`
+
+Small pages, disproportionate effect on whether AI systems will cite us:
+`/editorial-standards/`, `/translation-methodology/`, `/gita-ai-methodology/`, `/sources/`,
+`/contributors/`, `/corrections-policy/`, and `/how-we-tested-gita-ai/`.
+
+They need to explain which editions we use, which translations are licensed, who reviews
+explanations, how Gita AI cites verses, what we do when traditions disagree, how corrections
+get submitted, and how the recommendation pages were tested.
+
+---
+
+## 10. Chapter and verse page enrichment
+
+**Status:** todo
+**Branch:** `feat/chapter-verse-enrichment`
+
+All 18 chapter pages, then the 50 most-searched verse pages.
+
+Chapter pages need: overview, story context, main teachings, important verses, key Sanskrit
+concepts, practical applications, audio, available translations, FAQs, prev/next.
+
+Verse pages need: Sanskrit, transliteration, word-by-word meaning, Hindi and English
+translations, commentary, audio, plain-language explanation, practical application, related
+verses, and an "Ask Gita AI about this verse" prompt.
+
+Also in this layer: concept hubs under `/topics/` — karma, dharma, karma-yoga, bhakti-yoga,
+jnana-yoga, detachment, atman, moksha, meditation, three-gunas, mind-control, svadharma. These
+double as internal-linking hubs.
+
+---
+
+## 11. AI visibility benchmark
+
+**Status:** todo
+**Branch:** n/a — measurement, not code
+
+A tracked set of 100 prompts split across English and Hindi, India and US, recommendation and
+informational intent, run against Google AI Mode, ChatGPT, Gemini, Claude, Perplexity and
+Copilot. The full prompt list is in `notes/gtm-plan.md` — 15 app-discovery, 11
+website-discovery, 10 translation-and-study, 14 life-guidance, 13 scripture-facts.
+
+Record which brands appear, which sources get cited, and why. This is the measurement loop for
+items 7 through 10.
+
+**Crawler policy to settle first.** Review robots/CDN rules for Googlebot, Bingbot,
+OAI-SearchBot, GPTBot, ChatGPT-User, and the Perplexity and Anthropic crawlers. OpenAI
+separates its search crawler from its training crawler, so don't blanket-block anything with
+"GPT" in the name. Whether we allow GPTBot specifically is a deliberate call about training
+data, not a default.
+
+---
+
+## 12. OpenBenchmarks collaboration
+
+**Status:** blocked — commercial terms unresolved
+**Branch:** n/a — mostly off-domain
+
+A third party (openbenchmarks.com) has proposed collaborating on an independent benchmark of
+Bhagavad Gita apps, websites, and AI assistants. The memo's recommendation is to engage.
+
+Three benchmarks proposed: apps (10–15 of them across six scoring categories), websites, and a
+Gita AI reliability benchmark pitting Gita AI against ChatGPT, Gemini, Claude and Perplexity on
+whether they cite verses correctly. That third one is described as the most valuable output.
+
+**The independence constraint is the whole point.** We'd sponsor the category; they own
+methodology, testing, scoring and publication. We can supply domain knowledge and help define
+user needs, but if we control the scoring it reads as sponsored content dressed as research and
+does us no good with either competitors or LLMs. The memo accepts up front that we may not win
+every category, and argues that improves credibility.
+
+**Blocked on:** funding and independence terms, defining the competitor set, and recruiting two
+to four qualified Sanskrit or Gita reviewers.
+
+---
+
+## Conflicts to resolve before starting the GTM items
+
+These came out of the two notes disagreeing with each other. Worth settling early rather than
+discovering mid-build:
+
+1. **Who is the primary tester?** `gtm-plan.md` wants us running a rigorous comparison on our
+   own domain with our own tested date and reviewers. `gtm-open-benchmarks.md` says we must not
+   control the testing and must not mirror the benchmark onto our domain. Both can be true, but
+   only if our page adds something the benchmark doesn't. Decide what that something is.
+2. **Where does the benchmark sit in priority?** It doesn't appear in the plan's top ten at all,
+   but the benchmarks memo puts it in the GEO top five. The memo is the later, additive
+   document, so it probably wins, but that's a call to make explicitly.
+3. **Overlapping "best app for X" page sets** exist on both domains — 14 URLs on ours, 8 on
+   theirs. Canonicalization, differentiation and cross-linking are all unspecified.
+4. **Two different 100-item AI sets** are floating around and shouldn't be conflated. Item 11 is
+   a _visibility_ benchmark (do LLMs mention us). Item 12's is a _reliability_ benchmark (does
+   Gita AI cite verses correctly). Different purposes, both worth doing.
+
+---
+
+## Adjacent track: the scripture portfolio (not work in this repo)
+
+Source: `notes/chatgpt-ramayan.md`
+
+Separate from the site work above, there's a strategy note covering new exact-match-domain
+scripture properties modeled on what bhagavadgita.com has proven out. Recording it here so it
+isn't lost, but none of it ships from this repo.
+
+**The three properties, scored in the note:**
+
+| Property       | Opportunity | Execution difficulty |
+| -------------- | ----------- | -------------------- |
+| Ramayana       | 9/10        | 7/10                 |
+| Mahabharata    | 9.5/10      | 4/10                 |
+| Ramcharitmanas | 9/10        | 8/10                 |
+
+Recommended order: Ramayan first (smaller corpus at ~24,000 shlokas, and the Nitesh Tiwari
+film creates a demand window), Mahabharat as the bigger long-term prize (~100,000 verses,
+18 parvas), Ramcharitmanas as the cleanest exact-match opportunity since the head term has no
+intent ambiguity.
+
+**Structure:** each exact-match domain runs as its own branded vertical on shared
+infrastructure — one scripture database, one account system, one reading engine, one editorial
+workflow. Explicitly not three separate editorial systems, and not subfolders under an
+unfamiliar umbrella brand.
+
+**Where this repo is involved.** Only two things touch bhagavadgita.com:
+
+- Add a "Sanatan Scriptures" section that links contextually to the new properties
+- Use the "From the team behind BhagavadGita.com" byline on the new property for trust and
+  seeded distribution
+
+The note is firm that we should _not_ attempt authority transfer through aggressive sitewide
+links. Contextual, reader-useful links only. Editorially defensible cross-link topics it
+suggests: Gita references to Shri Ram, dharma across both texts, Krishna on divine
+incarnations, duty compared across the two.
+
+**Unresolved before anything starts:**
+
+- No verified Ahrefs or Search Console volumes yet. Every difficulty estimate is directional.
+- Domain availability is unconfirmed. `ReadRamayana.org` and `Ramcharitmanas.org` are already
+  occupied, so there's brand-confusion risk to check before buying anything nearby.
+- Ramcharitmanas text rights are unsettled. Gita Press scans being on Archive.org does not
+  make the translations, commentary, or audio reusable.
+- Mahabharata has a real textual alignment problem: Ganguli's English doesn't map cleanly onto
+  available Sanskrit chapter structures, so we'd have to pick a numbering authority.
+- The movie date is inconsistent within the note itself (Diwali 2026 vs November 2026). Needs
+  one confirmed date before anything is planned around it.
+
+Full detail, including URL structures, keyword difficulty tables, backlink tiers, paid-install
+economics and the six-month launch sequence, is in `notes/chatgpt-ramayan.md`.
+
+---
+
+## Backlog / ideas
+
+Site and technical:
+
+- Consolidate the brand tokens so the app page and the rest of the site can't drift
+- Review Core Web Vitals sitewide once `/app` is off jQuery
+- llms.txt for AI crawlers
+- Split XML sitemaps by content type: chapter, verse, topic, question, language
+- Fix duplicate translation URLs and tighten hreflang across the Hindi routes
+
+From the GTM notes, not yet scheduled:
+
+- **Gita AI distributed across the site** rather than living on one page. Contextual prompts on
+  every chapter, verse, topic and guidance page: explain this simply, compare three
+  commentaries, how do I apply this at work, explain in Hindi, show related verses, build me a
+  seven-day plan.
+- **Question and source-answer pages.** ~20 listed in the notes. The build/don't-build rule is
+  useful: only make a standalone page if it can offer citations, scholarly disagreement, a
+  table, a reading path, or a genuine next step. "How many chapters" is one sentence and doesn't
+  need 1,500 words wrapped around it.
+- **Public Gita AI question library** at `/ask/...`, indexable, but consent and moderation need
+  designing first.
+- **Daily short-form video engine** across YouTube Shorts, Reels, Facebook and X. Five recurring
+  formats, nine-step workflow, and a hard rule that nothing publishes without human review — a
+  wrong verse attribution costs more than a viral video earns.
+- **Growth experiments:** verse-to-video sharing, seven-day life challenges, a personalized
+  reading path based on why someone came, "Gita Wrapped" at year-end or Gita Jayanti,
+  shareable Gita AI answer cards, a creator and teacher program.
+- **Linkable assets** worth building because people cite them: cross-commentary comparison,
+  Sanskrit glossary, the Gita's timeline within the Mahabharata, a concept graph across all 700
+  verses, a "which verse discusses this" search, and an upgraded public API with proper docs,
+  versioning, provenance and citation guidelines.
+- **Anti-thin-content standard** for everything above: every important page needs at least three
+  genuine human contributions — editorial judgment, verified primary sources, real examples,
+  comparisons, expert review. Scaled low-value pages count against us whether or not AI wrote
+  them.

--- a/notes/chatgpt-ramayan.md
+++ b/notes/chatgpt-ramayan.md
@@ -1,0 +1,1867 @@
+Radhey Radhey see how easy or difficult to rank a new website exact match domain for Ramayan reading
+Also note that there is a new Ramayan movie being made and then there is it’s to series also
+Worked for 23s
+
+Radhey Radhey. This is a strong opportunity, but ranking for the single word “Ramayan” will be difficult. A new exact-match domain can rank relatively quickly for reading-focused long-tail searches, especially if we launch before the movie’s full promotional cycle peaks.
+
+My verdict
+Target Difficulty for a new site Realistic timeline
+“Ramayan” Very difficult 18–36+ months
+“Ramayana” Very difficult 18–36+ months
+“Ramayan in Hindi” Difficult 9–18 months
+“Ramayan read online” Medium 4–10 months
+“Valmiki Ramayana in Hindi” Medium 4–9 months
+“Ramayan all kand in Hindi” Medium 3–8 months
+Individual kand, sarga and verse queries Easy to medium 1–6 months
+Character, event and question pages Easy to medium 1–6 months
+
+These are directional estimates. I don’t yet have verified Ahrefs or Google Search Console volumes for the keyword set.
+
+Why this could work
+
+The current reading SERP isn’t dominated by one unbeatable, definitive Ramayana product.
+
+The visible competitors include:
+
+Mahakavya, offering Valmiki Ramayana in Hindi
+Wisdom Library, offering an English translation
+Ramcharitmanas.info, focused primarily on Ramcharitmanas
+Wikipedia
+YouTube and television episode pages
+IIT Kanpur and other broader scripture libraries
+
+Several results are old-fashioned reading experiences, broad scripture websites, or individual pages inside larger domains. There’s room for a purpose-built Ramayana reading product with excellent structure and multilingual content.
+
+And this is important: Ramayana has roughly 24,000 shlokas across seven kandas. That gives us thousands of legitimate, interconnected pages rather than a thin exact-match microsite.
+
+The exact-match domain advantage
+
+An exact-match domain helps with:
+
+Immediate relevance and memorability
+Higher click-through when someone wants to read the text
+Natural branded anchor text
+Easier word-of-mouth
+Becoming the destination people associate with the scripture
+
+But the truth is, the domain alone won’t rank.
+
+Google will still evaluate the content, page experience, backlinks, authorship, textual provenance and whether the site genuinely satisfies the query. A weak ramayan[something].com won’t outrank a complete, trusted library.
+
+The strongest domain would be:
+
+Ramayan.com
+Ramayana.com
+A short brand such as ReadRamayan.com
+A broader authoritative home, such as the Ved Vyas project, with /ramayana/
+
+For India, “Ramayan” is likely the more conversational and Hindi-friendly spelling. For international and academic discovery, “Ramayana” is stronger. Ideally, one becomes primary and the other redirects to it.
+
+The movie creates a huge window
+
+Nitesh Tiwari’s Ramayana is being released as a two-part project. Part 1 is scheduled around Diwali 2026, with Part 2 planned for Diwali 2027. The current promotional campaign is already accelerating, and the trailer is scheduled for July 24, 2026.
+
+It has also topped IMDb’s list of the most anticipated Indian films for the second half of 2026.
+
+This will create several waves:
+
+Trailer and cast searches
+“Real story” and character searches
+Comparisons between the film and Valmiki Ramayana
+Searches after watching Part 1
+Renewed interest before Part 2 in 2027
+International searches as dubbed versions and global promotion expand
+
+That gives us more than a one-week news spike. It could be an 18 to 24-month search-demand cycle.
+
+But the movie also creates a problem
+
+The keyword “Ramayana” will become mixed-intent.
+
+Someone searching “Ramayana” may want:
+
+The scripture
+The 2026 movie
+The cast
+The trailer
+The old Ramanand Sagar TV series
+Shrimad Ramayan
+Episodes on YouTube or Sony LIV
+Ramcharitmanas
+A summary for school
+
+Google may temporarily give more of the head-term SERP to entertainment sites, IMDb, YouTube, news publications and ticketing platforms. BookMyShow, IMDb, District and news publications are already competing for movie-related searches.
+
+So we shouldn’t build the SEO strategy around winning only “Ramayan.”
+
+We should own the clearer intent:
+
+Read the authentic Ramayana online, with Sanskrit, translation, audio and explanations.
+
+TV-series impact
+
+There’s already heavy television and video competition around this name.
+
+Ramanand Sagar’s episodes receive substantial YouTube demand, while Shrimad Ramayan has dedicated Sony LIV episode pages. The more recent Kakabhushundi Ramayan also ran through May 2026.
+
+This means searches like “Ramayan episode,” “Ramayan full,” and “Ramayan online” can have video intent.
+
+Therefore, our primary wording should be:
+
+Read Ramayan online
+Valmiki Ramayana text
+Ramayana shlokas and meaning
+Ramayan in Hindi
+Ramayana English translation
+Ramayana kand and sarga
+Original Ramayana story
+
+Avoid relying heavily on “watch,” “episode,” or “full Ramayan,” unless we also provide licensed or embedded video content.
+
+The site structure I’d build
+Core scripture pages
+/ramayana/
+/ramayana/bala-kanda/
+/ramayana/bala-kanda/sarga-1/
+/ramayana/bala-kanda/sarga-1/verse-1/
+
+Each verse page should contain:
+
+Sanskrit
+Transliteration
+Word-by-word meaning
+Hindi translation
+English translation
+Commentary
+Audio
+Previous and next verse
+Source and translator information
+High-intent landing pages
+/ramayan-in-hindi/
+/ramayana-in-english/
+/valmiki-ramayana/
+/ramayan-all-kand/
+/ramayan-with-meaning/
+/ramayan-audio/
+/ramayana-summary/
+
+These shouldn’t duplicate the scripture. They should be navigational reading hubs.
+
+Movie opportunity pages
+
+We should cover the movie without turning the sacred-text site into an entertainment blog:
+
+/ramayana-movie-vs-valmiki-ramayana/
+/ramayana-movie-characters-original-story/
+/ramayana-part-1-story-in-original-ramayana/
+/ranbir-kapoor-ramayana-characters/
+/ravana-in-valmiki-ramayana/
+/sita-in-valmiki-ramayana/
+
+The angle should always pull users back toward the source text.
+
+For example:
+
+Watched the Ramayana movie? Read the original passages describing Sita Swayamvar, vanvas, Hanuman’s journey and the battle of Lanka.
+
+Where the real SEO scale comes from
+
+The biggest opportunity isn’t the home page. It’s thousands of specific searches:
+
+Why did Ram go into exile?
+How many years was Ram in vanvas?
+Who was Mandodari?
+What did Kaikeyi ask Dasharatha?
+Where is Lakshman Rekha mentioned?
+Did Valmiki Ramayana mention Shabari’s berries?
+Difference between Ramayana and Ramcharitmanas
+Was Sita Swayamvar in Valmiki Ramayana?
+Sundar Kand in Hindi with meaning
+Bala Kand Sarga 1
+Ramayana verse about dharma
+
+These pages can cite the exact kand, sarga and shloka. That makes the site meaningfully better than generic mythology articles and AI-generated summaries.
+
+What would make it hard
+
+The project becomes much harder if:
+
+We publish only a copied public-domain translation
+Verse pages have almost identical titles and thin content
+Hindi rendering is poor
+There’s no clarity about the edition or translator
+We mix Valmiki Ramayana and Ramcharitmanas without labeling them
+We mass-generate explanations with factual errors
+We launch thousands of pages without internal links
+We treat the movie as the main product
+
+Sacred-text accuracy will also matter for trust. Every page should identify the source edition, translator, language and editorial process.
+
+My recommended positioning
+
+I’d build this as:
+
+The most complete place to read and understand the Ramayana online.
+
+Not merely:
+
+Ramayan in Hindi.
+
+And I’d include:
+
+Valmiki Ramayana first
+Hindi and English at launch
+Sanskrit and transliteration
+Audio
+Reader progress
+Book and study views
+Search by person, place, event and shloka
+Original-text answers to common questions
+Ramcharitmanas as a separately labeled scripture later
+Final recommendation
+
+Yes, we should do it. But I’d treat the exact-match domain as an accelerant, not the strategy itself.
+
+A strong execution could begin ranking long-tail pages within a few months. By Diwali 2026, we could have topical coverage and authority ready for the movie-driven demand. The bigger opportunity is building the enduring canonical Ramayana reading destination before entertainment intent completely occupies the head term.
+
+The best strategic setup may be:
+
+Exact-match Ramayan domain for distribution and brand recall, powered by the same scripture infrastructure as Ved Vyas.
+
+That gives us the SEO focus of a vertical site without rebuilding the underlying library twice.
+
+Radhey Radhey check top results on google tho
+Worked for 19s
+
+Radhey Radhey. You were right to question it. The live top results make the opportunity more nuanced: ranking for “Ramayan” or “Ramayana” is now extremely difficult because the movie is taking over the head-term SERP. But ranking for explicit reading searches still looks quite achievable.
+
+What the top results show right now
+
+1. “Ramayan” and “Ramayana”
+
+The results are currently dominated by:
+
+News about the 2026 film
+Ranbir Kapoor, Yash and Sai Pallavi coverage
+Trailer and promotional-event stories
+Wikipedia
+IMDb pages for the movie and older TV series
+YouTube episodes of Ramanand Sagar’s Ramayan
+Sony LIV’s Shrimad Ramayan
+
+Today’s results are particularly movie-heavy because a promotional event has just happened, with multiple major publications covering it.
+
+So for the bare keyword:
+
+Ramayan
+
+Google is trying to satisfy at least four intents:
+
+The upcoming movie
+Ramanand Sagar’s TV serial
+General information about the scripture
+Someone wanting to read or watch it
+
+That means a new reading website would struggle to rank in the first few positions for the bare word, even with an exact-match domain.
+
+2. “Read Ramayan online”
+
+This SERP is much more encouraging.
+
+The visible reading competitors include:
+
+ReadRamayana.org
+ValmikiRamayan.net
+Sacred-Texts
+Mahakavya
+SriRamWallpapers
+Google Books and archive sources
+
+ReadRamayana.org has perhaps the closest exact-intent domain and positioning. ValmikiRamayan.net is also highly relevant to the scripture itself.
+
+But many of these experiences have weaknesses:
+
+Older website design
+Weak mobile reading experience
+Limited navigation
+Mostly one translation
+Little or no personalization
+Poor multilingual discovery
+Few contextual explanations
+Limited structured data
+Weak brand and product experience
+
+Sacred-Texts, for example, hosts a complete public-domain English translation, but it’s based on a nineteenth-century edition and has a very basic reading interface.
+
+So this keyword cluster looks medium difficulty rather than difficult.
+
+3. “Valmiki Ramayana in Hindi”
+
+The leading organic competitors visible include:
+
+Mahakavya
+Ramcharit.in
+Hindi Wikipedia
+Google Play apps
+YouTube playlists
+PDFs and institutional documents
+
+Mahakavya has a dedicated Hindi landing page. Ramcharit.in says it’s working toward making all 24,000 shlokas available in digital HTML with Hindi meaning.
+
+This is the SERP where I see the clearest opportunity.
+
+Why? Because the ranking sites are relevant, but they aren’t unbeatable domains such as Wikipedia, YouTube or IMDb across every position. A technically excellent, complete Ramayana library could compete here.
+
+Revised difficulty
+Keyword Difficulty
+Ramayan Extremely high
+Ramayana Extremely high
+Ramayan movie Extremely high
+Ramayan serial Extremely high
+Read Ramayan online Medium
+Read Ramayana online in Hindi Medium
+Valmiki Ramayana in Hindi Medium
+Valmiki Ramayana Sanskrit Hindi Medium
+Ramayan all kand Medium
+Bala Kand Sarga 1 Low to medium
+Individual sarga and shloka searches Low
+Specific Ramayana questions Low to medium
+The most important finding
+
+The exact-match domain should not merely be Ramayan.com with a generic home page targeting “Ramayan.”
+
+Google may see the site as less relevant than:
+
+Film news for current-intent searches
+YouTube for watch intent
+Sony LIV for TV intent
+Wikipedia for informational intent
+Established scripture pages for reading intent
+
+Instead, the domain needs to establish a very clear entity:
+
+Ramayan.com is the place to read and understand the authentic Ramayana.
+
+And every title and heading should reinforce that reading intent.
+
+For example:
+
+Homepage title
+
+Read Ramayan Online in Hindi, English and Sanskrit | Valmiki Ramayana
+
+Homepage H1
+
+Read the Complete Valmiki Ramayana Online
+
+Supporting copy
+
+Sanskrit shlokas, Hindi and English translations, word meanings, audio and explanations across all seven kandas.
+
+How the movie changes our strategy
+
+The movie isn’t only competition. It’s a powerful acquisition channel.
+
+Right now, fresh movie coverage is already pushing scripture-reading results down for the head term. The film’s promotional campaign and upcoming trailer are producing daily news coverage.
+
+And the film is expected in November 2026, with the second part planned for 2027.
+
+So we need two SEO layers.
+
+Evergreen reading layer
+Complete Valmiki Ramayana
+Seven kanda pages
+Sarga pages
+Shloka pages
+Hindi and English translations
+Audio
+Character and place pages
+Movie-demand layer
+Ramayana movie story versus original Ramayana
+Characters in the Ramayana movie
+Where Part 1 ends in Valmiki Ramayana
+Ravana in the movie versus Valmiki Ramayana
+Sita’s story in the original Ramayana
+What happens after Ramayana Part 1
+Read the chapters depicted in the Ramayana movie
+
+This lets us capture entertainment demand and redirect it into scripture reading.
+
+What I’d now recommend
+Best standalone domain strategy
+
+Use a reading-focused exact-match or partial-match domain:
+
+Ramayan.com, if obtainable
+Ramayana.com, if obtainable
+ReadRamayan.com
+ReadRamayana.com
+ValmikiRamayan.com
+
+Interestingly, ReadRamayan.com may communicate the intent more clearly than Ramayan.com, even though the latter is the stronger pure exact match.
+
+There is already a ReadRamayana.org website, so we’d need to consider brand confusion and trademark or passing-off risk before choosing a very similar name.
+
+Updated conclusion
+
+A new exact-match domain won’t easily rank for “Ramayan” itself. The head SERP is becoming an entertainment battlefield, and that will intensify through November 2026.
+
+But the reading SERP is still fragmented and relatively weak. A complete, modern and authoritative website could realistically win:
+
+Read Ramayan online
+Valmiki Ramayana in Hindi
+Ramayana Sanskrit with Hindi meaning
+Ramayan all kand
+Thousands of individual sarga, shloka and question searches
+
+So I’d still build it. But I’d model the business case around owning Ramayana reading, not around ranking number one for the naked word “Ramayan.”
+
+Radhey Radhey what about Mahabharat
+Worked for 22s
+
+Radhey Radhey. Mahabharat may actually be the better long-term reading-site opportunity than Ramayan. The head keyword is still difficult, but the reading results are older, fragmented, and surprisingly weak from a product perspective.
+
+What appears across the top results
+
+For broad searches such as “Mahabharat”, Google largely sees television and general-information intent. Prominent results include:
+
+JioHotstar’s 2013 Mahabharat
+Wikipedia
+IMDb
+YouTube episodes and playlists from B. R. Chopra’s series
+Hindi Wikipedia
+Articles about characters, stories, and individual incidents
+
+JioHotstar has a highly relevant page specifically titled Mahabharat, while YouTube has full-episode playlists with the exact Hindi title. These are formidable competitors for people trying to watch Mahabharat.
+
+So ranking a new scripture site for the naked keyword “Mahabharat” would still be very difficult.
+
+But reading intent is much weaker
+
+For searches around reading the complete Mahabharata, the main results include:
+
+Sacred Texts
+Wisdom Library
+Project Gutenberg
+Archive.org
+mahabharata-online.github.io
+PDFs and digital-library copies
+Amazon and book publishers
+
+Sacred Texts hosts the complete Ganguli English translation, but the interface is an old directory-style website. Project Gutenberg splits the work into large volumes. The GitHub-hosted reading site is functional, but it has almost no consumer brand or modern reading experience.
+
+Wisdom Library is probably the strongest structured web competitor. It has the full Ganguli translation broken into books and sections, although it remains part of a much broader library rather than a purpose-built Mahabharata product.
+
+This is exactly the type of SERP where a focused new website can break through.
+
+Mahabharat versus Ramayan
+Factor Ramayan Mahabharat
+Difficulty of the bare keyword Extremely high Very high
+Current movie interference Extremely high Moderate
+TV-series interference High Very high
+Quality of online reading competitors Moderate Low to moderate
+Number of indexable content pages Large Extremely large
+Character and question search opportunity Large Enormous
+Complexity of building the corpus Medium Extremely high
+Opportunity for a definitive destination Strong Potentially stronger
+The important distinction
+
+Ramayan currently has a major upcoming film reshaping its head SERP.
+
+Mahabharat has strong television competition, including the older B. R. Chopra adaptation, the 2013 Star Plus adaptation, and the AI-generated Mahabharat: Ek Dharmayudh. But it doesn’t currently have one comparable confirmed blockbuster release dominating every search result.
+
+Aamir Khan has discussed an ambitious Mahabharata adaptation, but that project appears much less concrete than the Ramayana movie’s present release campaign.
+
+That gives a Mahabharat reading site more time to establish authority before another major entertainment wave.
+
+My difficulty estimate
+Keyword New-site difficulty
+Mahabharat Very high
+Mahabharata Very high
+Mahabharat serial Extremely high
+Mahabharat episodes Extremely high
+Read Mahabharat online Medium
+Read Mahabharata online Medium
+Complete Mahabharata in English Medium
+Mahabharat in Hindi Medium to high
+Mahabharat all parva in Hindi Medium
+Mahabharata Sanskrit with Hindi meaning Medium
+Adi Parva chapter-specific searches Low to medium
+Individual stories and questions Low to medium
+Why Mahabharat has a bigger SEO surface
+
+The Mahabharata contains roughly 100,000 verses and is organized across 18 major parvas. Even estimates and textual traditions vary, but it is dramatically larger than the Ramayana.
+
+That creates several layers of pages:
+
+/mahabharata/
+/mahabharata/adi-parva/
+/mahabharata/adi-parva/sambhava-parva/
+/mahabharata/adi-parva/section-1/
+/mahabharata/adi-parva/section-1/verse-1/
+
+Then there are separate entity pages:
+
+/characters/karna/
+/characters/bhishma/
+/characters/draupadi/
+/characters/krishna/
+/places/hastinapura/
+/events/dyuta-sabha/
+/events/kurukshetra-war/
+
+And thousands of question pages:
+
+Why did Karna support Duryodhana?
+Who was older, Karna or Yudhishthira?
+Why did Bhishma take his vow?
+Did Draupadi reject Karna?
+Who killed Abhimanyu?
+Why didn’t Krishna fight in the war?
+How did each Kaurava die?
+What happened after the Mahabharata war?
+Is the Lakshagriha story in the original Mahabharata?
+Which original section describes Draupadi’s disrobing?
+
+This question layer could become bigger than the scripture-reading traffic itself.
+
+The current competitors have a major weakness
+
+Most sites provide one of these:
+
+A Victorian English translation
+A giant PDF
+Sanskrit without usable alignment
+A summary
+Television episodes
+Isolated mythology articles
+
+Very few provide all of this together:
+
+Original Sanskrit
+Verse-aligned Hindi and English
+Modern readable English
+Source and edition transparency
+Character relationships
+Events in chronological order
+Maps and family trees
+Audio
+Search across characters, verses, and events
+Comparison between popular stories and the source text
+
+Sacred Texts says its Sanskrit version can only be cross-referenced to Ganguli’s English translation at the book level because the chapter structures don’t align cleanly. That shows both the challenge and the opportunity.
+
+Exact-match domain potential
+
+The ideal domains would be:
+
+Mahabharat.com
+Mahabharata.com
+ReadMahabharat.com
+ReadMahabharata.com
+VyasaMahabharata.com
+
+For India, Mahabharat is likely stronger for everyday Hindi and Hinglish searches.
+
+For international readers, academics, and English-language searches, Mahabharata is the standard spelling.
+
+A smart setup would own both spellings, choose one canonical domain, and redirect the other.
+
+But would the exact match alone work? No. The real moat would be the information architecture and source alignment.
+
+The biggest challenge
+
+Mahabharat is substantially harder to build correctly than Ramayan.
+
+There are multiple textual recensions, editions, translations, section-numbering systems, and differences between the vulgate and Critical Edition. Even the complete public-domain Ganguli translation doesn’t map perfectly to available Sanskrit chapter structures.
+
+So every page needs to state clearly:
+
+Textual edition
+Parva and sub-parva
+Section or adhyaya numbering
+Translator
+Whether numbering follows Ganguli, the Critical Edition, or another source
+Whether the English has been modernized
+Whether additions are editorial explanations
+
+Without that, the site could become technically large but academically unreliable.
+
+My actual recommendation
+
+I’d prioritize them like this:
+
+For faster launch and cleaner corpus
+
+Ramayan first.
+
+It is smaller, easier to structure, and the movie offers immediate demand.
+
+For the largest enduring SEO and knowledge opportunity
+
+Mahabharat is stronger.
+
+It has:
+
+More pages
+More characters
+More questions
+More philosophical topics
+More disputed popular beliefs to clarify
+Weaker modern reading products
+Better potential for graphs, maps, timelines, and entity search
+
+The truth is, Mahabharat could become the flagship of Ved Vyas rather than merely another scripture section.
+
+Best strategic structure
+
+Rather than launching completely separate technical products, I’d build:
+
+vedvyas.org/ramayana/
+vedvyas.org/mahabharata/
+
+And acquire the exact-match domains as focused entry points:
+
+Mahabharat.com → vedvyas.org/mahabharata/
+Ramayan.com → vedvyas.org/ramayana/
+
+But for maximum standalone SEO, each domain could run as its own branded vertical while sharing the same database, reader, search system, accounts, and editorial infrastructure.
+
+My overall score:
+
+Ramayan opportunity: 8.5/10
+Mahabharat opportunity: 9/10
+Ease of execution, Ramayan: 8/10
+Ease of execution, Mahabharat: 4/10
+
+Mahabharat is the bigger mountain. But because the existing digital experience is so fragmented, reaching the summit could create a far stronger and more defensible destination.
+
+Radhey Radhey is it better to have Ramayan or Ramayana in the domain
+Worked for 12s
+
+Radhey Radhey. For your project, I’d choose Ramayana in the primary domain, then buy the equivalent Ramayan domain and redirect it. Ramayana gives you broader authority, international recognition, and cleaner association with the original Sanskrit epic.
+
+My recommendation
+Primary brand and domain
+
+Ramayana.com or ReadRamayana.com
+
+Defensive domain
+
+Ramayan.com or ReadRamayan.com, redirected permanently to the primary domain.
+
+Why I’d choose Ramayana
+
+1. It’s the canonical English spelling
+
+The original Sanskrit name is commonly transliterated as Rāmāyaṇa. “Ramayana” is therefore the standard spelling used by:
+
+Encyclopedias
+Universities and researchers
+English-language books
+International readers
+Cultural institutions
+Most authoritative English references
+
+Google also understands “Ramayana” as the ancient Sanskrit epic entity, while “Ramayan” is used more conversationally in India.
+
+That matters because you’re building an authoritative digital scripture destination, not only a Hindi-content website.
+
+2. It travels better internationally
+
+Think about where this could go over ten years.
+
+You may eventually have:
+
+Sanskrit
+Hindi
+English
+Tamil
+Telugu
+Gujarati
+Spanish
+Indonesian
+Thai
+Academic citations
+Apps and international partnerships
+
+“Ramayana” will look natural across those audiences. “Ramayan” can feel like a Hindi or Indian-English spelling.
+
+3. It distinguishes the scripture from entertainment
+
+The word Ramayan has a strong association with Indian television, especially Ramanand Sagar’s serial. Users frequently search “Ramayan” when they want episodes or videos.
+
+“Ramayana” is more strongly associated with:
+
+The epic itself
+Valmiki
+Books and translations
+Scholarship
+International versions
+
+With the new film also using Ramayana, there will still be movie competition. But a name like Read Ramayana immediately disambiguates your purpose.
+
+4. It gives the brand more gravitas
+
+Compare these aloud:
+
+Ramayan, read the timeless epic online.
+
+Ramayana, the definitive digital home of the timeless epic.
+
+The second feels more complete and enduring. Would you name the definitive scripture library after the colloquial spelling, or the globally recognized title?
+
+For your Ved Vyas vision, I’d lean toward the latter.
+
+Where Ramayan is stronger
+
+“Ramayan” still has some meaningful advantages:
+
+Shorter by one character
+Easier for Hindi-speaking users to type
+Matches common Indian pronunciation
+Likely strong for Hinglish searches
+Familiar from television and everyday conversation
+Better if the product is primarily for Indian mass-market users
+
+Many Indian pages naturally use wording such as “Ramayan in Hindi”, while still using “Ramayana” elsewhere on the page. The Mahakavya result is one example.
+
+So I wouldn’t ignore the spelling. I’d capture it through titles, copy, redirects, and alternate spellings.
+
+SEO impact is smaller than it appears
+
+Google explicitly says that domain-name keywords alone have hardly any ranking effect. It also has systems designed to prevent exact-match domains from receiving excessive ranking credit.
+
+Therefore:
+
+Ramayan.com won’t automatically rank better for “Ramayan.”
+Ramayana.com can still rank for both “Ramayana” and “Ramayan.”
+Content quality, links, structure, authority, and reading experience will matter far more.
+
+Google understands these as spelling variants of the same underlying entity.
+
+Best implementation
+
+I’d set it up like this:
+
+Primary domain: readramayana.com
+Brand name: Ramayana
+Site name: Read Ramayana
+Redirect: readramayan.com → readramayana.com
+
+Homepage SEO title:
+
+Read Ramayana Online in Hindi, English and Sanskrit
+
+Homepage H1:
+
+Read the Complete Valmiki Ramayana
+
+Supporting text can include the alternate spelling naturally:
+
+Read the complete Ramayan online, with original Sanskrit shlokas, Hindi and English translations, audio, and explanations.
+
+That lets the brand remain Ramayana, while pages capture Indian “Ramayan” searches.
+
+My ranking
+Option Brand strength India appeal Global appeal Authority
+Ramayan 8.5/10 10/10 7/10 8/10
+Ramayana 9.5/10 9/10 10/10 10/10
+Read Ramayan 8.5/10 10/10 7.5/10 8/10
+Read Ramayana 9.5/10 9/10 10/10 9.5/10
+Final choice
+
+Choose Ramayana for the main domain and brand.
+
+But secure Ramayan too, because it’s too important an Indian spelling to leave open. Redirect it to the canonical domain and use both variants strategically in page titles and content.
+
+For a premium standalone destination, my order would be:
+
+Ramayana.com
+ReadRamayana.com
+Ramayan.com
+ReadRamayan.com
+ValmikiRamayana.com
+Radhey Radhey what about ramcharitmanas
+Worked for 13s
+
+Radhey Radhey. Ramcharitmanas is an excellent standalone opportunity, but I wouldn’t use it instead of Ramayana. I’d treat it as a separate scripture and potentially a separate exact-match domain.
+
+The opportunity looks strong
+
+The current reading results include:
+
+IIT Kanpur’s Ramcharitmanas site
+Ramcharitmanas.info
+Ramcharitmanas.org
+Mahakavya
+Webdunia
+Archive.org and scanned Gita Press editions
+Smaller Hindi-content sites
+
+The SERP is relevant, but most results still lack a polished, modern, mobile-first reading experience. IIT Kanpur has authority and useful audio, while Ramcharitmanas.info offers Hindi, English and audio. Still, neither clearly owns the definitive consumer reading experience across search, study, audio, progress and commentary.
+
+So the competition is stronger than Mahabharat’s reading SERP, but still very beatable with superior execution.
+
+Domain spelling
+
+For this scripture, I’d strongly use:
+
+Ramcharitmanas
+
+Not:
+
+Ramcharit Manas
+Ram Charit Manas
+Ramacharitmanas
+Ramacharitamanasa
+
+Ramcharitmanas is the most practical modern spelling. It’s how Wikipedia, major reading sites, apps and most current search results label the work.
+
+Ideal domain order
+Ramcharitmanas.com
+Ramcharitmanas.org
+ReadRamcharitmanas.com
+ShriRamcharitmanas.com
+TulsiRamayan.com
+
+But Ramcharitmanas.org is already being used by an existing reading website, so a similar domain could create brand confusion.
+
+Ramayana versus Ramcharitmanas
+
+They shouldn’t be mixed as though they’re interchangeable.
+
+    Valmiki Ramayana	Ramcharitmanas
+
+Author Maharishi Valmiki Goswami Tulsidas
+Original language Sanskrit Awadhi
+Primary audience opportunity India and global Primarily India and diaspora
+Best spelling Ramayana Ramcharitmanas
+Reading behaviour Study, story, scholarship Reading, paath, singing, devotion
+SEO emphasis Verses, sargas, story questions Dohas, chaupais, kand, meaning, paath
+Movie benefit Directly significant Indirect but meaningful
+
+Ramcharitmanas is an Awadhi devotional epic by Tulsidas, structured across seven kandas or sopans. It’s distinct from Valmiki’s Sanskrit Ramayana, despite narrating the life and deeds of Shri Ram.
+
+Where Ramcharitmanas may be stronger
+
+It has exceptionally strong devotional search intent:
+
+Ramcharitmanas in Hindi
+Ramcharitmanas with meaning
+Sampurn Ramcharitmanas
+Ramcharitmanas paath
+Akhand Ramayan paath
+Ramcharitmanas chaupai
+Ramcharitmanas doha
+Sundarkand paath
+Bal Kand in Hindi
+Ramcharitmanas audio
+Ramcharitmanas PDF
+
+People don’t only want information. They want to read, recite, listen and continue their daily paath.
+
+That makes it ideal for:
+
+Reading progress
+Daily paath plans
+Audio synchronized with text
+Large Devanagari typography
+Chaupai and doha sharing
+Bookmarking
+Meaning in simple Hindi
+Offline access
+Family and temple usage
+The largest SEO advantage
+
+Ramcharitmanas has a cleaner head term than Ramayan.
+
+A search for “Ramayan” can mean:
+
+The Valmiki scripture
+Ramcharitmanas
+A television series
+The upcoming movie
+A general story of Shri Ram
+
+But “Ramcharitmanas” is highly specific. Google knows which work the user wants.
+
+That reduces intent ambiguity and gives an exact-match domain a clearer topical identity.
+
+Difficulty estimate
+Keyword Difficulty
+Ramcharitmanas High
+Ramcharitmanas in Hindi Medium to high
+Read Ramcharitmanas online Medium
+Sampurn Ramcharitmanas Medium
+Ramcharitmanas with Hindi meaning Medium
+Ramcharitmanas audio Medium
+Individual doha or chaupai Low to medium
+Specific kand passages Low to medium
+Meaning of a particular chaupai Low
+The exact site structure
+/ramcharitmanas/
+/ramcharitmanas/bal-kand/
+/ramcharitmanas/bal-kand/doha-1/
+/ramcharitmanas/bal-kand/doha-1/chaupai-1/
+
+Each unit could contain:
+
+Original Awadhi in Devanagari
+Roman transliteration
+Simple Hindi meaning
+English translation
+Commentary
+Audio
+Context before and after
+Meter type, such as doha, chaupai, soratha or chhand
+Source edition
+
+And dedicated paath routes:
+
+/ramcharitmanas/daily-paath/
+/ramcharitmanas/9-day-paath/
+/ramcharitmanas/30-day-paath/
+/sundarkand-paath/
+/akhand-ramayan-paath/
+
+That’s how we build something existing digital texts don’t offer.
+
+One major issue: text editions and rights
+
+You’ll need to distinguish between:
+
+The original Tulsidas text
+The particular editorial edition used
+Modern Hindi explanations
+English translations
+Audio recordings
+
+Scanned Gita Press books are widely uploaded online, including through Archive.org, but that doesn’t automatically mean every translation, commentary, page design or audio recording is free to reuse.
+
+The safest model is:
+
+Use a verified original Awadhi text
+Establish the source edition clearly
+Create or license your own Hindi meaning
+Create or license your own English translation
+Record or properly license audio
+Document editorial variants where important
+Would I buy the exact-match domain?
+
+Yes, absolutely, provided the price is reasonable.
+
+My opportunity scores:
+
+Property Opportunity Execution difficulty
+Ramayana 9/10 7/10
+Mahabharata 9.5/10 4/10
+Ramcharitmanas 9/10 8/10
+
+Mahabharata’s execution score is lower because it’s harder to complete correctly.
+
+Ramcharitmanas may produce stronger repeat usage than either. Someone might research Mahabharata once, but a devotee could return daily for paath.
+
+My recommendation for Ved Vyas
+
+Build the scriptures distinctly under one platform:
+
+vedvyas.org/ramayana/
+vedvyas.org/ramcharitmanas/
+vedvyas.org/mahabharata/
+
+Then acquire exact-match domains as entry points:
+
+Ramayana domain → Valmiki Ramayana
+Ramcharitmanas domain → Tulsidas’s Ramcharitmanas
+Mahabharata domain → Vyasa Mahabharata
+
+Most importantly, don’t redirect Ramcharitmanas visitors to a generic “Ramayan” page. Give it its own identity, reading structure and devotional experience.
+
+Purely as an exact-match SEO and recurring-product opportunity, Ramcharitmanas may actually be the cleanest of the three.
+
+Radhey Radhey reset online, how much to exact match domains help now and do it for Bhagavad-Gita, where I got bhagavadgita.com, and it’s ranking currently at least in India and the top results for that keyword. I have some authority from before, but yeah now .com thing, probably pushed to the top three or four results. You can check and then let me know.
+Worked for 34s
+
+Radhey Radhey. Your bhagavadgita.com example shows the real modern value of an exact-match domain very well. The domain probably didn’t independently push the site into the top results, but it likely amplified the authority, relevance, clicks, links, and user recognition you had already built.
+
+What I can verify right now
+
+For a broad search for “Bhagavad Gita,” bhagavadgita.com is being surfaced among the leading organic results alongside Wikipedia and established scripture sites such as holy-bhagavad-gita.org. It also appears strongly for related pages and Hindi intent.
+
+I can’t reliably declare one universal position such as number three because rankings vary by:
+
+Location within India
+Language and device
+Search history
+Google experiments
+Whether videos, books, images, or other modules appear
+
+But your observation is credible. The site has clear first-page, top-tier visibility for the head entity, which is extremely valuable.
+
+How much do exact-match domains directly help now?
+
+Google’s official position is quite restrained.
+
+Google says:
+
+Words inside a domain are one of many relevance factors
+Its exact-match-domain system prevents those words from receiving excessive credit
+Keywords in the domain alone have “hardly any effect” beyond breadcrumb presentation
+
+So the direct algorithmic benefit is probably small.
+
+My practical estimate:
+
+Benefit Likely importance
+Direct keyword-ranking signal Low
+Immediate topical understanding Low to moderate
+Search-result click-through rate Moderate to high
+Brand recall Very high
+Natural exact-match backlinks High
+Trust and perceived authority High
+Navigational searches over time Very high
+Defensibility once established Very high
+
+That distinction is crucial.
+
+An exact-match domain isn’t a ranking cheat anymore. It’s a brand and distribution advantage that compounds into ranking signals.
+
+What probably happened with BhagavadGita.com
+
+I’d break your current performance into five components.
+
+1. You already had historical authority
+
+You previously operated a well-known Bhagavad Gita product. That can produce:
+
+Existing links
+Returning users
+Branded searches
+Mentions across websites and app ecosystems
+Familiarity with the product
+Existing indexed verse and chapter URLs
+
+That prior authority is likely a much larger ranking contributor than the domain string by itself.
+
+2. The domain perfectly matches the entity
+
+bhagavadgita.com isn’t a spammy phrase like:
+
+best-free-bhagavad-gita-online-reading.com
+
+It’s the exact proper name of the scripture.
+
+That creates an unusually clean match between:
+
+Domain
+Site name
+Homepage title
+Main entity
+Content corpus
+User intent
+
+Google sees Bhagavad Gita consistently across the entire site. The domain contributes to that overall coherence, even though it isn’t a powerful standalone signal.
+
+3. It probably improves click-through rate
+
+Imagine the results:
+
+Wikipedia
+Some institutional PDF
+holy-bhagavad-gita.org
+bhagavadgita.com
+
+For someone wanting to read the Bhagavad Gita, which result feels like the canonical destination?
+
+BhagavadGita.com looks definitive before the user even reads the description.
+
+That can improve:
+
+Click propensity
+Direct visits
+Repeat visits
+Searcher recognition
+Sharing and word of mouth
+
+Google doesn’t publicly describe CTR as a simple direct ranking factor. But users consistently choosing and returning to a result is strategically valuable regardless.
+
+4. Backlinks naturally contain the target keyword
+
+People linking to the site will often write:
+
+Bhagavad Gita
+BhagavadGita.com
+Read the Bhagavad Gita
+Bhagavad Gita app
+
+Even a naked URL contains the full entity name.
+
+That makes the backlink profile naturally topical without requiring artificial anchor-text optimization.
+
+This may be one of the biggest hidden benefits of a true exact-match domain.
+
+5. The .com increases perceived ownership
+
+The .com itself receives no special Google ranking boost over another generic TLD. Google says .com, .org, and other generic domains aren’t ranked differently simply because of their extension.
+
+But humans don’t treat them identically.
+
+For a globally recognized scripture:
+
+BhagavadGita.com feels like the category owner
+BhagavadGita.org feels like one organization
+ReadBhagavadGita.com feels like one product
+BhagavadGitaSomething.com feels secondary
+
+So the .com likely helps user trust, recall, linking, and direct traffic. Those indirect advantages can become meaningful.
+
+How much credit would I assign to the domain?
+
+Without comparing Search Console data before and after the migration, this can only be an informed estimate.
+
+For bhagavadgita.com, I’d roughly attribute the ranking strength like this:
+
+Contributor Rough share
+Existing site and backlink authority 30–40%
+Quality, completeness and structure of content 25–35%
+Exact-match domain and unified entity branding 15–25%
+User engagement, brand searches and repeat usage 10–20%
+Technical SEO and internal linking 10–15%
+
+These categories overlap, so this isn’t a literal ranking formula.
+
+But I wouldn’t say the domain only contributes 1% because Google says the direct keyword signal is weak. That ignores the indirect compounding effect.
+
+For a mature category-defining site, the exact-match .com could easily improve total SEO performance by 15–30% compared with an unknown arbitrary brand, even though the direct algorithmic keyword boost is much smaller.
+
+Why scripture exact matches are unusually valuable
+
+Exact-match domains work differently for proper entities than for commercial search phrases.
+
+Compare:
+
+cheapcarinsurance.com
+bestlaptops.com
+bhagavadgita.com
+ramayana.com
+mahabharata.com
+
+The first two look like SEO-targeted keyword domains.
+
+The latter three are the literal names of works. They can become genuine brands and definitive resources.
+
+Google’s exact-match-domain adjustment is meant to prevent low-quality sites from ranking solely because their domains match queries. It does not prevent a high-quality site from becoming authoritative under the most logical name.
+
+That’s why your Bhagavad Gita result is a strong precedent for Ramayana and Mahabharata.
+
+What this changes for Ramayana
+
+Based on the Bhagavad Gita case, I’d increase the strategic value I place on owning the pure exact-match .com.
+
+Revised priority
+Ramayana.com
+Ramayan.com
+Mahabharata.com
+Mahabharat.com
+Ramcharitmanas.com
+ReadRamayana.com
+
+Earlier, I treated ReadRamayana.com as nearly comparable. I’d revise that.
+
+If the pure exact-match .com is genuinely available at a commercially reasonable price, it’s materially better because it can become:
+
+The entity’s canonical digital destination.
+
+Ramayan versus Ramayana, reconsidered
+
+Your Bhagavad Gita case strengthens the argument for Ramayana.com.
+
+Why?
+
+Because BhagavadGita.com matches the canonical global name of the scripture. Similarly:
+
+Ramayana.com matches the canonical global name
+Ramayan.com matches the widely used Indian colloquial form
+
+For a global, multilingual, authoritative scripture platform, I’d use:
+
+Ramayana.com as primary
+
+And redirect:
+
+Ramayan.com to Ramayana.com
+
+But there’s one important commercial exception.
+
+If Ramayan.com is obtainable and Ramayana.com is prohibitively expensive, Ramayan.com is still an extremely strong asset for India. It may even attract higher Indian direct-type and Hinglish recognition.
+
+What this suggests for your overall portfolio
+
+There’s a potential category-ownership strategy here:
+
+BhagavadGita.com
+Ramayana.com
+Mahabharata.com
+Ramcharitmanas.com
+
+All can share:
+
+One content and scripture database
+One account system
+One reading engine
+One mobile app architecture
+One editorial workflow
+One broader Ved Vyas mission
+
+But each exact-match domain can operate as a focused, authoritative destination.
+
+That’s far stronger than forcing every scripture under one unfamiliar umbrella and hoping users learn the parent brand first.
+
+My final conclusion
+
+Exact-match domains have weak direct ranking power today, but premium exact-match .com domains still have substantial total SEO value.
+
+Your bhagavadgita.com performance is likely the combination of:
+
+Existing authority + quality scripture content + exact entity match + .com credibility + better user recognition.
+
+The domain didn’t magically create the authority. But once authority existed, it likely helped concentrate and amplify it.
+
+So for Ramayana, Mahabharata, and Ramcharitmanas, I’d now value the exact-match .com more aggressively than I did in my earlier answers. For these sacred-text entities, it can be a genuine long-term category moat.
+
+Today 7:40 PM
+Radhey Radhey check for org, ai domains also
+
+If we don't get.com, then which other domains can we get?
+
+Also, is it better to have the website and app both, or, if we have to choose one, should we put in time and effort on the Android and iOS app that will grow faster, or more on the website? With the app, we can also put ads, which in a couple of weeks reduce down to like ₹1.50 per install, so that is also another option.
+
+Let me know what would be our go-to-market strategy for the website. The other key is that the website is actually quite old, so that's why it's able to rank now. What would be needed to build backlinks or do any other things so that we can start ranking for the main set of keywords for a man within a couple of weeks or months? Do the proper strategy analysis for both the app and website, and then let me know.
+
+Radhe, Radhe!
+Worked for 1m 39s
+
+Radhey Radhey. For this project, the website should be the primary growth engine, while Android becomes the retention and paid-acquisition engine. If we must choose only one today, I’d choose the website, then release Android once the core reader and content database are working.
+
+1. Domain strategy beyond .com
+
+A domain lookup must be confirmed directly at a registrar immediately before purchase. The absence of a live or indexed website does not mean the domain is available. Registered domains can have no DNS, remain parked, or be privately held.
+
+A few relevant names are already visibly occupied:
+
+ReadRamayana.org operates an international Ramayana reading project.
+Ramcharitmanas.org is already associated with an existing scripture-reading property.
+Similar .ai branding also exists in the app ecosystem, including an app called “Ramayan AI,” so brand-confusion checks matter even when the exact domain appears open.
+My TLD ranking for a scripture project
+TLD Recommendation Best use
+.com 10/10 Definitive global destination
+.org 9/10 Nonprofit, cultural or public-service library
+.in 8/10 India-first mass-market product
+.app 7.5/10 Companion app or app-led product
+.ai 6.5/10 AI assistant, not the primary scripture
+.io 6/10 Technology product, weaker devotional fit
+.net 5.5/10 Acceptable fallback, but less memorable
+.co 5/10 Risk of traffic leaking to .com
+.org versus .ai
+
+For the main scripture destination, .org is much better than .ai.
+
+Why?
+
+A name such as:
+
+Ramayana.org
+
+communicates preservation, education, authenticity and public service.
+
+But:
+
+Ramayana.ai
+
+suggests an AI-generated interpretation, chatbot, or technology experiment. That may reduce trust for the canonical text. It also risks making the project feel temporary when the mission is timeless.
+
+I’d use .ai only for a clearly separated feature:
+
+AskRamayana.ai
+GitaAI-style question answering
+Character and story exploration
+Source-grounded explanations
+Voice conversations
+
+The canonical text should live on .com, .org, or possibly .in.
+
+2. Recommended domains by scripture
+   Ramayana
+
+My order would be:
+
+Ramayana.com
+Ramayan.com
+Ramayana.org
+Ramayan.org
+ValmikiRamayana.com
+ValmikiRamayan.com
+ReadRamayana.com
+Ramayana.in
+ValmikiRamayana.org
+Ramayana.app
+
+I’d put Ramayana.ai below all of these for the main library.
+
+Mahabharata
+Mahabharata.com
+Mahabharat.com
+Mahabharata.org
+Mahabharat.org
+VyasaMahabharata.com
+ReadMahabharata.com
+Mahabharata.in
+Mahabharata.app
+Mahabharata.ai
+Ramcharitmanas
+Ramcharitmanas.com
+Ramcharitmanas.org
+ShriRamcharitmanas.com
+Ramcharitmanas.in
+ReadRamcharitmanas.com
+TulsiRamayan.com
+Ramcharitmanas.app
+Ramcharitmanas.ai
+My practical fallback
+
+Suppose the exact .com is unavailable or absurdly expensive.
+
+I’d choose:
+
+Ramayana.org over a long or awkward .com.
+
+For example, Ramayana.org is stronger than:
+
+ReadTheCompleteOriginalRamayanaOnline.com
+
+A clean exact-match .org can still become the category brand. Google doesn’t give .com a special ranking advantage merely because it is .com. The difference is primarily human trust, memorability and commercial convention.
+
+3. Website versus app
+
+The question is really:
+
+Do we want discovery first, or retention first?
+
+The website is best for discovery.
+
+The app is best for habit, retention and paid distribution.
+
+Website strengths
+Every kanda, sarga and verse can rank separately.
+Google can surface pages for thousands of questions.
+Movie-related searches can become acquisition channels.
+Pages can earn backlinks.
+Users can enter without installing anything.
+Content can appear in standard search, AI answers and shared links.
+A web page works across Android, iOS and desktop.
+It builds the authority of the exact-match domain.
+
+Google uses the mobile version of a website for indexing and ranking, so the site must be genuinely mobile-first.
+
+App strengths
+Better daily-reading experience
+Offline content
+Push notifications
+Reading streaks
+Bookmarks and progress
+Verse of the day
+Audio downloads
+Better repeat usage
+Home-screen presence
+Paid-install campaigns
+App-store discovery
+
+Google Ads supports campaigns optimized either for maximum install volume or for users likely to complete valuable in-app actions.
+
+But app content doesn’t create the same breadth of publicly crawlable acquisition pages as a website.
+
+4. What I’d choose
+   If only one can be built
+
+Build the website.
+
+Especially now, because the Ramayana movie provides a limited SEO window. The website needs time to:
+
+Get crawled
+Establish its entity
+Earn links
+Build historical signals
+Rank kanda and sarga pages
+Accumulate branded searches
+Become associated with “read Ramayana”
+
+An app can be advertised and scaled later. Lost SEO time is harder to recover.
+
+If we can build both sensibly
+
+Build one shared content engine:
+
+Shared scripture API/database
+↓
+Next.js mobile-first website
+↓
+React Native Android and iOS apps
+
+Do not build three separate editorial systems.
+
+The website URLs should map directly to app screens:
+
+ramayana.org/bala-kanda/sarga-1
+↓
+App opens Bala Kanda, Sarga 1
+
+Google supports Android App Links and iOS Universal Links for sending users from a web result or shared link into the corresponding app content.
+
+5. Suggested priority split
+
+For the first six months:
+
+Workstream Resources
+Website, technical SEO and content 55%
+Shared backend and content pipeline 20%
+Android app 20%
+iOS app 5%
+
+Why Android first? Because the core market is India, acquisition is cheaper, and you’ve already seen CPIs around ₹1.50.
+
+The iOS app can follow once:
+
+Android retention is proven
+The reader is stable
+Content synchronization works
+Push-notification loops are validated 6. What ₹1.50 installs actually mean
+
+At ₹1.50 per install:
+
+10,000 installs cost ₹15,000
+100,000 installs cost ₹1.5 lakh
+1 million installs cost ₹15 lakh
+
+That’s extraordinarily cheap distribution.
+
+But installs alone can become a vanity metric. The campaign may find people who install and never read.
+
+The real funnel should be:
+
+Install
+→ Open
+→ Select language
+→ Begin first reading
+→ Finish one sarga
+→ Return the next day
+→ Complete seven-day streak
+
+I’d measure:
+
+Cost per first sarga started
+Cost per first sarga completed
+Day-1 retention
+Day-7 retention
+Day-30 retention
+Audio-start rate
+Reading-plan activation
+Cost per retained reader
+Organic installs generated per paid install
+
+Once there is enough event data, move from optimizing only for installs toward the first meaningful action. Google explicitly supports optimizing app campaigns toward in-app actions rather than only install volume.
+
+Paid-install strategy
+
+Phase 1:
+
+Optimize for installation
+Hindi first
+Android first
+Broad devotional and scripture creative
+Test Ramayan, Valmiki Ramayana, Sundar Kand and daily-paath messaging
+
+Phase 2:
+
+Optimize for completing one reading session
+Exclude low-retention placements or audiences
+Separate audio listeners from text readers
+Create returning-user campaigns
+
+Phase 3:
+
+Run movie-triggered creatives
+“Read the original story”
+“What happens after Part 1?”
+“See the original verses behind the film”
+Deep-link into exact chapters 7. The website GTM
+
+The mistake would be launching 24,000 shloka pages and waiting for Google.
+
+The website GTM should have five parallel motions.
+
+Motion 1: Own reading intent first
+
+Do not begin by trying to rank only for “Ramayan.”
+
+Start with clusters where Google knows the person wants text:
+
+Read Ramayana online
+Valmiki Ramayana in Hindi
+Ramayana in English
+Complete Ramayana Sanskrit
+Ramayana Sanskrit with Hindi meaning
+Ramayan all kand
+Bala Kand online
+Sundara Kanda Sanskrit and meaning
+Valmiki Ramayana chapter-wise
+Ramayana shlokas with meaning
+
+Build dedicated hubs for these intents rather than sending everything to one homepage.
+
+Example:
+
+/
+/valmiki-ramayana/
+/ramayana-in-hindi/
+/ramayana-in-english/
+/ramayana-sanskrit/
+/bala-kanda/
+/ayodhya-kanda/
+/sundara-kanda/
+
+Then connect those hubs to all sarga and verse pages.
+
+Motion 2: Create a source-answer layer
+
+This is where we can beat generic mythology websites.
+
+Publish answers such as:
+
+Is Lakshman Rekha mentioned in Valmiki Ramayana?
+Did Shabari taste the berries?
+Did Sita participate in a swayamvar?
+Who was older, Rama or Bharata?
+What did Kaikeyi actually ask Dasharatha?
+Where is Hanuman’s meeting with Sita described?
+Which chapters cover Rama’s exile?
+What happens after Ravana’s death?
+
+Each answer should cite:
+
+Kanda
+Sarga
+Shloka
+Translation
+Textual edition
+Relevant passage
+
+This isn’t a generic blog. It’s a source-grounded Ramayana knowledge layer.
+
+That can attract search traffic, journalist citations and natural links.
+
+Motion 3: Capture the movie wave
+
+Create one high-quality movie hub, but keep the scripture site’s identity clear.
+
+/ramayana-movie/
+/ramayana-movie-vs-valmiki-ramayana/
+/ramayana-movie-characters/
+/read-the-original-ramayana/
+/story-covered-in-ramayana-part-1/
+
+Create pages around major promotional moments:
+
+Trailer launch
+Character introductions
+Songs
+Release
+Interviews mentioning scripture accuracy
+Part 1 ending
+Part 2 speculation
+
+But don’t create shallow celebrity-news pages. Every page must connect entertainment interest to the original text.
+
+The winning format is:
+
+“Here is what the film depicts, and here is where the event appears in Valmiki Ramayana.”
+
+Motion 4: Build repeat-use features
+
+SEO brings the first visit. Product creates the brand.
+
+The website should support:
+
+Continue reading
+Daily reading plans
+Seven-day and 30-day plans
+Bookmarks
+Audio synced with text
+Font-size controls
+Hindi and English switching
+Sanskrit plus transliteration
+Dark mode
+Shareable shloka images
+Installable PWA
+Optional sign-in
+
+An indexable PWA is viable, but pages need clean URLs, crawlable content and server-side or hybrid rendering. Google explicitly recommends crawlable content and deep URLs rather than redirecting every internal route to an app homepage.
+
+Motion 5: Build distribution outside Google
+
+The initial distribution channels should include:
+
+Existing BhagavadGita.com readers
+Existing Bhagavad Gita app users
+JKYog and devotional communities, where appropriate
+Temple and paath communities
+Sanskrit and Indology contributors
+Hindi religious publishers
+YouTube explainers
+WhatsApp sharing
+Schools and cultural organizations
+Diaspora associations 8. Can it rank within weeks?
+What can happen in two to four weeks
+
+A new site can reasonably achieve:
+
+Indexation of major hubs
+Ranking for its own brand
+Impressions for long-tail sarga searches
+Some rankings for exact chapter titles
+Discovery through Google Search Console
+Initial referral traffic
+Rankings for pages with almost no competition
+What is unlikely in two to four weeks
+
+A genuinely new domain is unlikely to reach the top three for:
+
+Ramayan
+Ramayana
+Valmiki Ramayana
+Ramayan in Hindi
+
+The exact-match domain doesn’t change that enough. Google says domain keywords are only one relevance factor, and its exact-match-domain system prevents them from receiving excessive credit.
+
+A realistic progression
+Period Plausible result
+Weeks 1–4 Indexation, brand rankings, first long-tail impressions
+Months 2–3 Sarga pages and specific questions begin ranking
+Months 4–6 Reading-intent hubs enter stronger competition
+Months 6–12 Potential first-page positions for mid-tail terms
+Months 12–24 Realistic challenge for major head terms
+
+That can move faster if we acquire a relevant aged domain, preserve its URLs, and inherit genuine backlinks. It can also move faster through powerful existing distribution.
+
+9. How to use the old Bhagavad Gita authority
+
+You’re correct that age and accumulated authority probably explain a meaningful part of BhagavadGita.com’s current ranking.
+
+But we shouldn’t try to transfer authority through aggressive sitewide links.
+
+Instead:
+
+Add a genuine scripture network
+
+On BhagavadGita.com:
+
+Add a “Sanatan Scriptures” section
+Link contextually to the Ramayana project
+Publish an editorial page explaining the broader mission
+Cross-link relevant concepts, personalities and teachings
+Use organization and publisher relationships transparently
+
+Examples:
+
+Bhagavad Gita references to Shri Ram
+Dharma in Bhagavad Gita and Ramayana
+Krishna’s description of divine incarnations
+Comparison of duty across the two texts
+
+These are defensible links because they help readers.
+
+Preserve visible shared ownership
+
+Use language such as:
+
+From the team behind BhagavadGita.com.
+
+That can accelerate:
+
+Trust
+Direct traffic
+Branded searches
+Press coverage
+Newsletter acquisition
+App installs
+Natural links
+
+It won’t magically transfer all ranking strength, but it gives a cold-start site a credible launch story.
+
+10. Backlink plan
+
+We shouldn’t buy hundreds of generic links. For a sacred-text project, authority and provenance are the link magnets.
+
+Tier 1: Foundational links
+
+Target:
+
+Sanskrit departments
+University Indian-studies departments
+Digital humanities projects
+Cultural organizations
+Temples
+Hindu educational organizations
+Translation projects
+Public-domain and open-source directories
+Relevant Wikipedia citations, only where the resource genuinely supports the claim
+
+Create a scholarly “Text and editions” page that explains:
+
+Source manuscript or edition
+Sanskrit source
+Translation source
+Editorial changes
+Verse numbering
+Licensing
+Contributors
+
+People are much more willing to cite a transparent primary resource.
+
+Tier 2: Linkable assets
+
+Build assets that deserve links:
+
+Complete Ramayana family tree
+Interactive map of Rama’s journey
+Chronological event timeline
+Kanda and sarga explorer
+Character relationship database
+Comparison of popular stories with Valmiki’s text
+Searchable Sanskrit phrase index
+Open structured Ramayana dataset
+Translation-comparison tool
+Movie-to-scripture chapter guide
+
+A recent academic project has already highlighted the value of machine-readable, provenance-aware, sarga-aligned Ramayana corpora. That validates the potential academic usefulness of a properly structured corpus.
+
+Tier 3: Digital PR
+
+Potential stories:
+
+“The team behind BhagavadGita.com launches the complete digital Valmiki Ramayana”
+“A source-grounded guide separates the original Ramayana from popular adaptations”
+“Every scene from the 2026 Ramayana film mapped to the original text”
+“The complete Ramayana is now searchable across Sanskrit, Hindi and English”
+“Open digital corpus preserves 24,000 shlokas with source provenance”
+
+Pitch:
+
+Indian national publications
+Religion and culture publications
+Education media
+Technology media
+Movie publications at the right moment
+Diaspora media
+Sanskrit and literary communities
+Tier 4: Contributor distribution
+
+Bring in identifiable contributors:
+
+Sanskrit scholars
+Translators
+Hindi editors
+Ramayana teachers
+Audio reciters
+Cultural historians
+
+Give each contributor a proper profile and attribution. Their institutions and communities may naturally reference their work.
+
+Google emphasizes helpful, reliable, people-first content. Clear sourcing and recognizable expertise help users evaluate reliability, especially for complex religious texts.
+
+11. Technical requirements for fast SEO
+
+Before launch:
+
+Server-render every important page
+Unique URLs for each kanda, sarga and verse
+No hash-based routing
+XML sitemaps split by content type
+HTML links between every level
+Canonicals correctly configured
+Hindi and English pages separated
+Proper hreflang
+Fast mobile rendering
+No content hidden behind login
+Breadcrumb structured data
+Article or relevant creative-work structured data
+Author and source pages
+Search Console configured on day one
+IndexNow where supported, although Google still relies on its own crawling
+Accurate last-modified dates
+Persistent URLs that won’t change later
+
+Google recommends simple, descriptive URLs and URLs in the audience’s language where appropriate.
+
+And internal navigation must use crawlable text links. Google explicitly notes that text links are easy for search engines to discover and crawl.
+
+12. My recommended launch sequence
+    Month 1
+
+Launch the mobile website with:
+
+All seven kanda hubs
+At least one complete language
+Sarga-level pages
+50 foundational question pages
+Source and editorial methodology
+Search
+Reading progress stored locally
+Email or WhatsApp opt-in
+PWA installation
+
+Do not wait for every feature.
+
+Month 2
+Add Hindi and English alignment
+Launch Android beta
+Add audio for priority sections
+Publish movie and source-comparison hub
+Begin contributor outreach
+Launch the family tree and map
+Start digital PR
+Months 3–4
+Scale to 200 to 300 source-grounded answers
+Begin Android paid acquisition
+Optimize toward reading completion
+Add app deep links
+Launch daily reading plans
+Start partnerships and backlink campaigns
+Months 5–6
+Launch iOS
+Create Part 1 movie-reading guide
+Run large paid-install campaigns
+Push shareable verse cards
+Expand languages
+Strengthen pages that already receive impressions in Search Console
+Final recommendation
+
+I’d do this:
+
+Primary asset: exact-match .com, otherwise exact-match .org
+Primary growth engine: mobile-first website
+Primary retention engine: Android app
+Secondary platform: iOS after Android retention is proven
+AI domain: optional companion, never the canonical scripture
+
+And I’d allocate effort as follows:
+
+Launch website immediately
+Build Android from the shared backend in parallel
+Use paid installs once activation tracking is installed
+Use BhagavadGita.com’s audience and credibility for the launch
+Build source-grounded pages, not generic SEO articles
+Use the 2026 film as a distribution event
+Expect long-tail movement in weeks, meaningful reading-keyword rankings in months, and head-term competition over 12 to 24 months
+
+The app can grow faster in visible user numbers. But the website creates the compounding asset: search authority, backlinks, public discoverability and ownership of the category.

--- a/notes/gtm-open-benchmarks.md
+++ b/notes/gtm-open-benchmarks.md
@@ -1,0 +1,452 @@
+Radhey Radhey. **Yes, we should add this as a major action item.** A well-designed, independently hosted Bhagavad Gita benchmark could become one of our strongest GEO assets for “best Bhagavad Gita app,” “best Hindi Gita app,” and related recommendation prompts.
+
+But the benchmark must be more than a comparison article with scores invented to make BhagavadGita.com win. It should be reproducible, transparent, regularly updated, and useful even when another product wins a category.
+
+## Why the benchmark could help
+
+OpenBenchmarks structures its existing benchmark around:
+
+- The same test inputs for every provider
+- Clearly defined metrics
+- Public results
+- Different winners for different use cases
+- Open data and code
+- Supporting pages targeting specific recommendation questions
+
+Its lookalike benchmark, for example, tests vendors on identical seed companies and reports precision at different cutoffs. It doesn’t force one universal winner. One provider leads for top-ten accuracy, while another leads for longer result lists. ([Openbenchmarks for Agents][1])
+
+That format is valuable for AI visibility because it creates:
+
+1. A structured dataset
+2. Clear, quotable conclusions
+3. A methodology page
+4. Category-specific winner statements
+5. Third-party corroboration outside our domain
+6. Multiple pages answering recommendation prompts
+
+And crucially, OpenBenchmarks publishes underlying data and code, which makes the claims easier to verify and cite. ([Openbenchmarks for Agents][2])
+
+## My recommendation
+
+Create two separate benchmarks:
+
+### 1. Bhagavad Gita App Benchmark
+
+Evaluate Android and iOS apps.
+
+### 2. Bhagavad Gita Website Benchmark
+
+Evaluate websites for reading, study, translation access, source transparency, and usability.
+
+Don’t combine apps and websites into one leaderboard. The jobs are different, and combining them would produce confusing scores.
+
+## Benchmark one: Bhagavad Gita apps
+
+A strong first version could test 10 to 15 leading apps across six categories.
+
+### A. Scripture completeness
+
+Measure objectively:
+
+- All 18 chapters available
+- All 700 traditionally counted verses available
+- Sanskrit text
+- Transliteration
+- Word-by-word meaning
+- Chapter summaries
+- Verse explanations
+- Commentary availability
+- Multiple translators
+- Source attribution
+
+### B. Language coverage
+
+Measure:
+
+- Number of complete languages
+- Whether only interface text is translated
+- Whether scripture translations are complete
+- Hindi availability
+- Regional Indian languages
+- English availability
+- Transliteration support
+- Language switching quality
+
+Don’t simply award one point per language. Ten incomplete machine-translated languages shouldn’t beat three carefully edited translations.
+
+A better score could include:
+
+- Completeness
+- Human attribution
+- Editorial review
+- Coverage across all chapters
+- Consistency
+
+### C. Reading experience
+
+Test:
+
+- Font controls
+- Dark mode
+- Search
+- Bookmarks
+- Reading progress
+- Offline reading
+- Chapter navigation
+- Verse sharing
+- Cross-device sync
+- Accessibility
+- App speed
+- Login requirements
+- Advertisements
+
+### D. Learning experience
+
+Measure:
+
+- Audio recitation
+- Audio translation
+- Sanskrit pronunciation
+- Commentary
+- Concept explanations
+- Daily verse
+- Reading plans
+- Quizzes
+- Memorisation tools
+- Video lessons
+- Related-verse discovery
+
+### E. AI experience
+
+This could become the most differentiated section.
+
+Test each app’s AI against a fixed set of perhaps 100 questions:
+
+- Does the answer cite exact verses?
+- Are citations correct?
+- Does the cited verse support the answer?
+- Does it distinguish scripture from commentary?
+- Does it acknowledge interpretive differences?
+- Does it avoid inventing Sanskrit?
+- Does it answer in Hindi correctly?
+- Does it stay within Bhagavad Gita sources when requested?
+- Does it handle sensitive mental-health questions responsibly?
+- Does it refuse unsupported claims?
+
+The AI evaluation should include human review. An LLM judge can assist, but religious accuracy shouldn’t depend solely on another model.
+
+### F. Trust and accessibility
+
+Measure:
+
+- Free versus paid
+- Subscription transparency
+- Advertisements
+- Privacy disclosures
+- Account required
+- Developer identity
+- Translation attribution
+- Editorial methodology
+- Corrections process
+- Store rating
+- Review volume
+- Last update
+- Data collection
+
+## Avoid one meaningless total score
+
+A single overall score is tempting, but it can hide what users actually care about.
+
+Instead, publish category winners:
+
+- Best overall Bhagavad Gita app
+- Best free Bhagavad Gita app
+- Best Hindi Bhagavad Gita app
+- Best for beginners
+- Best for serious study
+- Best for multiple commentaries
+- Best audio experience
+- Best offline app
+- Best AI-guided experience
+- Best for daily reading
+- Best privacy-conscious app
+- Best for children or families
+
+OpenBenchmarks uses this same underlying principle. Its pages explicitly say there isn’t always one “best” provider, because the right winner depends on the workflow. ([Openbenchmarks for Agents][3])
+
+That makes the benchmark more credible and creates many citation-ready conclusions.
+
+## Benchmark two: Bhagavad Gita websites
+
+Evaluate sites such as:
+
+- BhagavadGita.com
+- Holy Bhagavad Gita
+- Gita Supersite
+- Vedabase
+- SrimadGita
+- Other prominent Hindi and multilingual resources
+
+Potential dimensions:
+
+| Dimension           | Example measurements                          |
+| ------------------- | --------------------------------------------- |
+| Text completeness   | Chapters, verses, missing content             |
+| Translations        | Languages, translators, completeness          |
+| Commentary          | Number, attribution, traditions represented   |
+| Study features      | Search, glossary, related verses, comparisons |
+| Audio               | Verse audio, translation audio, completeness  |
+| Usability           | Mobile experience, speed, readability         |
+| Source transparency | Editions, translators, editorial policy       |
+| Accessibility       | Free access, login barriers, ads              |
+| AI features         | Accuracy, citations, multilingual support     |
+| Technical quality   | Stable URLs, crawlability, structured pages   |
+
+Again, publish use-case winners rather than manufacturing a universal victory.
+
+## The most important rule: independence
+
+Because BhagavadGita.com would be included, the benchmark needs visible safeguards.
+
+The benchmark should state:
+
+- Who funded it
+- Who designed the methodology
+- Who collected the data
+- Whether BhagavadGita.com had input
+- Whether OpenBenchmarks independently executed the tests
+- How scores were calculated
+- How vendors can challenge errors
+- When the benchmark was last updated
+- Whether all raw evidence is available
+
+I’d prefer this model:
+
+> BhagavadGita.com sponsors the benchmark category, but OpenBenchmarks owns the methodology, testing, scoring, and publication.
+
+We can provide category knowledge and help define important user needs. But we shouldn’t control the final scoring.
+
+Otherwise, competitors and LLMs may interpret it as sponsored native advertising dressed up as research.
+
+## Translation quality needs careful treatment
+
+We can objectively compare:
+
+- Number of translations
+- Languages
+- Completeness
+- Named translators
+- Publication dates
+- Commentary availability
+- Word-by-word meaning
+- Public-domain or licensed status
+
+But “most accurate translation” is much harder.
+
+Different translations reflect:
+
+- Sanskrit interpretation
+- Sampradaya
+- Commentary tradition
+- Literal versus interpretive style
+- Intended audience
+- Theological assumptions
+
+Therefore, don’t produce one simplistic “translation accuracy score.”
+
+Use categories such as:
+
+- Best literal translation
+- Best beginner-friendly translation
+- Best traditional devotional translation
+- Best academically annotated translation
+- Best Hindi translation
+- Best for word-by-word study
+
+And publish the evaluation criteria and reviewer backgrounds.
+
+## Build a benchmark question set for Gita AI
+
+This may be the most valuable output of the collaboration.
+
+We could create an open **Bhagavad Gita AI Reliability Benchmark** covering:
+
+### Factual grounding
+
+- How many chapters are in the Bhagavad Gita?
+- In which Mahabharata parva does it occur?
+- Who narrates the dialogue to Dhritarashtra?
+- Which verse begins Krishna’s direct teaching?
+
+### Verse retrieval
+
+- Which verse discusses the wandering mind?
+- Which verse says one has responsibility for action?
+- Which verses describe the three gunas?
+- Which verse discusses lifting oneself through the mind?
+
+### Interpretation
+
+- Does detachment mean indifference?
+- Does the Gita encourage violence?
+- Is karma yoga opposed to bhakti?
+- What does surrender mean in Chapter 18?
+
+### Citation reliability
+
+- Did the model cite the correct chapter and verse?
+- Does the quoted Sanskrit actually match the verse?
+- Does the translation correspond to the cited source?
+- Did it invent a verse?
+
+### Tradition awareness
+
+- Can it distinguish Shankaracharya’s interpretation from Ramanuja’s?
+- Does it present contested interpretations as settled fact?
+- Can it explain differences without declaring one tradition illegitimate?
+
+### Modern guidance
+
+- Career uncertainty
+- Grief
+- Anger
+- Anxiety
+- Failure
+- Family obligations
+- Leadership
+- Discipline
+
+This benchmark could compare:
+
+- Gita AI
+- General ChatGPT
+- Gemini
+- Claude
+- Perplexity
+- Other specialised spiritual assistants
+
+That gives us a genuinely newsworthy and academically useful benchmark, not merely an app feature comparison.
+
+## Pages that the benchmark could generate
+
+The benchmark should have one canonical dataset and multiple useful interpretations:
+
+```text
+openbenchmarks.com/bhagavad-gita-apps/
+openbenchmarks.com/bhagavad-gita-apps/best-overall/
+openbenchmarks.com/bhagavad-gita-apps/best-hindi-app/
+openbenchmarks.com/bhagavad-gita-apps/best-free-app/
+openbenchmarks.com/bhagavad-gita-apps/best-for-beginners/
+openbenchmarks.com/bhagavad-gita-apps/best-with-audio/
+openbenchmarks.com/bhagavad-gita-apps/best-with-commentary/
+openbenchmarks.com/bhagavad-gita-apps/best-ai-app/
+openbenchmarks.com/bhagavad-gita-websites/
+openbenchmarks.com/bhagavad-gita-ai/
+```
+
+Then BhagavadGita.com can publish supporting pages that reference the independent benchmark:
+
+```text
+bhagavadgita.com/app/
+bhagavadgita.com/best-bhagavad-gita-apps/
+bhagavadgita.com/best-bhagavad-gita-app-in-hindi/
+bhagavadgita.com/gita-ai/
+bhagavadgita.com/how-we-tested-gita-ai/
+```
+
+The two should add different value. Don’t copy the entire benchmark onto BhagavadGita.com.
+
+## How this helps AI citations
+
+The likely mechanism isn’t that LLMs see the word “benchmark” and automatically trust it.
+
+The benchmark becomes valuable because it supplies:
+
+- Explicit comparisons
+- Machine-readable tables
+- Specific scores
+- Named methodology
+- Current dates
+- Evidence
+- Multiple external mentions
+- Open data
+- Stable URLs
+- Clear winners by use case
+
+For example, an AI system can extract:
+
+> BhagavadGita.com ranked first for Hindi language coverage, with complete text in X languages and Y Hindi study features.
+
+That’s substantially more citable than:
+
+> BhagavadGita.com is the best Bhagavad Gita app.
+
+## Additional distribution plan
+
+Publishing the benchmark alone won’t be enough.
+
+Launch it through:
+
+- Product Hunt or Hacker News, if the AI reliability angle is substantial
+- Indian technology and culture publications
+- Hindu and spiritual publications
+- App review sites
+- Sanskrit and Indology scholars
+- AI evaluation communities
+- Reddit communities where appropriate
+- YouTube app reviewers
+- Spiritual creators
+- LinkedIn research posts
+- GitHub and Kaggle datasets
+- University digital-humanities outreach
+
+The strongest PR angle may be:
+
+> We tested the leading Bhagavad Gita apps and AI assistants on scripture accuracy, citations, translation support, and practical guidance.
+
+That is more interesting than another “top ten apps” article.
+
+## Action item to add
+
+### Bhagavad Gita Benchmark Program
+
+**Objective:** Establish the most credible independent benchmark for Bhagavad Gita apps, websites, and AI assistants, earning citations across Google and AI platforms.
+
+**First deliverables:**
+
+1. Define the app and website competitor set.
+2. Create objective product-feature criteria.
+3. Design the 100-question Gita AI evaluation set.
+4. Recruit two to four qualified Sanskrit or Gita reviewers.
+5. Agree on funding and independence terms with OpenBenchmarks.
+6. Run tests on fixed devices and app versions.
+7. Publish raw evidence, methodology, and scoring.
+8. Release category-specific pages.
+9. Run a coordinated PR and creator campaign.
+10. Monitor which benchmark conclusions get cited across Google AI Mode, Gemini, ChatGPT, Claude, and Perplexity.
+
+## Where I’d place it in the broader roadmap
+
+This should become one of the top five GEO actions:
+
+1. Build trustworthy app and website comparison pages.
+2. Launch the independent Bhagavad Gita benchmark.
+3. Publish the Gita AI accuracy benchmark.
+4. Earn third-party reviews and institutional mentions.
+5. Track recommendation prompts across major AI systems.
+
+## Final view
+
+**Yes, respond positively to the founder and explore the collaboration.** The app-feature benchmark alone is worthwhile, but the real moat would be combining it with a rigorous Gita AI reliability benchmark.
+
+That creates three benefits simultaneously:
+
+- BhagavadGita.com can earn legitimate “best for X” recognition.
+- The industry gets an open standard for evaluating Gita apps and AI answers.
+- AI platforms receive structured, externally hosted evidence they can cite.
+
+And even if BhagavadGita.com doesn’t win every category, that may actually improve the benchmark’s credibility. The goal isn’t to rig a leaderboard. The goal is to define the category and make sure we’re objectively excellent on the dimensions that matter.
+
+[1]: https://openbenchmarks.com/lookalikes?utm_source=chatgpt.com "Lookalike Benchmark - Similar Companies APIs"
+[2]: https://openbenchmarks.com/?utm_source=chatgpt.com "Openbenchmarks for Agents"
+[3]: https://openbenchmarks.com/lookalikes/most-accurate-company-lookalike-api?utm_source=chatgpt.com "The most accurate company lookalike API - Benchmarks."

--- a/notes/gtm-plan.md
+++ b/notes/gtm-plan.md
@@ -1,0 +1,1135 @@
+Radhey Radhey. **BhagavadGita.com has a much bigger opportunity than a normal content site because you already own the category-defining domain, rank for the head term, have an established app, and have Gita AI.** I’d build the next growth phase around three engines: searchable scripture content, practical life guidance, and product-recommendation visibility across Google and AI platforms.
+
+The goal should be to move from roughly **20,000 to 100,000 monthly organic visits**, while simultaneously increasing app installs, repeat reading, branded searches, and citations inside AI answers.
+
+# The strategic opportunity
+
+Right now, the site is strongest where the domain naturally helps:
+
+- Bhagavad Gita
+- Bhagavad Gita online
+- Bhagavad Gita chapters
+- Bhagavad Gita Chapter 1
+- Popular verse searches
+
+The homepage already has a solid scripture structure. It links all 18 chapters, highlights popular verses, and answers several foundational questions. But most of the available search surface remains unbuilt. ([Bhagavad Gita][1])
+
+There are four large surfaces we can expand into:
+
+1. **Scripture searches:** chapters, verses, translations, audio, commentaries.
+2. **Problem searches:** anxiety, career, anger, grief, relationships, purpose.
+3. **Recommendation searches:** best Gita app, website, translation, commentary.
+4. **AI prompts:** questions asked inside ChatGPT, Gemini, Claude, Google AI Mode, and Perplexity.
+
+The important part is that these shouldn’t become four disconnected content farms. Everything should connect back to exact verses, named translations, expert commentary, and the product.
+
+# What SrimadGita is doing
+
+SrimadGita has created a deliberate AEO-style content system.
+
+Its pages include:
+
+- A dedicated app landing page
+- Best Bhagavad Gita app comparisons
+- Best translations comparisons
+- Beginner-specific app pages
+- App-with-commentary pages
+- Anxiety and workplace-stress pages
+- Career-success pages
+- Practical-life lesson hubs
+- Popular-shloka collections
+
+Its app page places a short “quick answer” near the top, followed by features, use cases, a comparison table, testimonials, FAQs, and app-store links. ([Srimad Gita][2])
+
+It also has highly specific pages such as:
+
+- Best Bhagavad Gita app for beginners
+- Best Bhagavad Gita app with multiple commentaries
+- Bhagavad Gita solutions for workplace stress
+- How to overcome anxiety through the Gita
+- Best Bhagavad Gita translations ([Srimad Gita][3])
+
+That explains why it can appear for many recommendation and AI-style queries despite being newer.
+
+## What it does well
+
+It structures pages so machines can extract answers quickly:
+
+- Clear question in the title
+- Direct answer near the top
+- Comparison tables
+- Distinct audience recommendations
+- Pros and cons
+- FAQs
+- Related resources
+- External references
+- Disclosure that it owns the recommended product
+
+Its main comparison page even includes evaluation methodology and discloses that SrimadGita is its own product. ([Srimad Gita][4])
+
+## Where we can beat it
+
+Some of its pages make strong claims such as “best,” “highest quality,” or “most comprehensive,” while using its own app as the winner. Some listed ratings, review counts, features, and app details need independent verification before they should be trusted or copied. ([Srimad Gita][4])
+
+BhagavadGita.com can build a stronger position through:
+
+- Independent testing criteria
+- Screenshot evidence
+- Verified store ratings and review counts
+- Transparent update dates
+- Clear ownership disclosure
+- Named human reviewers
+- Religious and editorial review
+- Better side-by-side demonstrations
+- More balanced recommendations
+
+In other words, don’t merely imitate the page format. **Build the trustworthy version of it.**
+
+# The recommended site architecture
+
+I’d create six interconnected content layers.
+
+## 1. Canonical scripture layer
+
+This is the foundation and should remain the most authoritative part of the site.
+
+```text
+/chapters/
+/chapter/1/
+/chapter/1/verse/1/
+/chapter/1/summary/
+/chapter/1/meaning/
+/chapter/1/commentary/
+/chapter/1/audio/
+/chapter/1/in-hindi/
+```
+
+Each chapter page should include:
+
+- Chapter overview
+- Story context
+- Main teachings
+- Important verses
+- Key Sanskrit concepts
+- Practical applications
+- Audio
+- Available translations
+- FAQs
+- Previous and next chapters
+
+Each verse page should include:
+
+- Sanskrit
+- Transliteration
+- Word-by-word meaning
+- Hindi translation
+- English translation
+- Commentary
+- Audio
+- Plain-language explanation
+- Practical application
+- Related verses
+- “Ask Gita AI about this verse”
+
+The current homepage already surfaces chapter summaries and popular verses, so the next step is creating much richer chapter and verse pathways around that existing foundation. ([Bhagavad Gita][1])
+
+## 2. Topic and concept layer
+
+Create definitive hubs around Gita concepts:
+
+```text
+/topics/karma/
+/topics/dharma/
+/topics/karma-yoga/
+/topics/bhakti-yoga/
+/topics/jnana-yoga/
+/topics/detachment/
+/topics/atman/
+/topics/moksha/
+/topics/meditation/
+/topics/three-gunas/
+/topics/mind-control/
+/topics/svadharma/
+```
+
+Each topic page should answer:
+
+- What does the concept mean?
+- Which chapters explain it?
+- Which verses are most relevant?
+- How do different commentators explain it?
+- What are common misunderstandings?
+- How does someone apply it today?
+- What related topics should they study next?
+
+These pages can rank for broad educational searches and become strong internal-linking hubs.
+
+## 3. Life-situation layer
+
+This is probably the largest untapped traffic surface.
+
+```text
+/guidance/anxiety/
+/guidance/anger/
+/guidance/fear/
+/guidance/grief/
+/guidance/depression/
+/guidance/overthinking/
+/guidance/failure/
+/guidance/career-confusion/
+/guidance/workplace-stress/
+/guidance/exam-stress/
+/guidance/relationship-problems/
+/guidance/family-pressure/
+/guidance/loneliness/
+/guidance/decision-making/
+/guidance/life-purpose/
+/guidance/discipline/
+/guidance/leadership/
+/guidance/jealousy/
+/guidance/procrastination/
+/guidance/death-and-loss/
+```
+
+But these shouldn’t say:
+
+> The Bhagavad Gita cures anxiety.
+
+That would be medically irresponsible and spiritually simplistic.
+
+A better framing is:
+
+> What the Bhagavad Gita teaches about responding to anxiety and uncertainty.
+
+Each page should contain:
+
+1. The human problem
+2. Krishna’s relevant teaching
+3. Three to seven exact verses
+4. Commentary from a named source
+5. A practical reflection
+6. What the Gita doesn’t claim
+7. A prompt to explore the issue through Gita AI
+8. Related reading
+
+SrimadGita is already targeting anxiety, workplace stress, career success, and practical modern-life questions. ([Srimad Gita][5])
+
+This validates the demand, but we should make the content more grounded, nuanced, and source-led.
+
+## 4. Questions and source-answer layer
+
+These are the contextual queries you mentioned.
+
+Examples:
+
+- In which parva of Mahabharata is the Bhagavad Gita?
+- Who heard the Bhagavad Gita besides Arjuna?
+- How long did Krishna take to speak the Bhagavad Gita?
+- Why did Krishna teach the Gita on a battlefield?
+- Who wrote the Bhagavad Gita?
+- Why are there 700 verses?
+- What is the first verse of the Bhagavad Gita?
+- What is the final teaching of the Bhagavad Gita?
+- What does Krishna say about anger?
+- What does the Gita say about death?
+- Does the Gita support war?
+- What does the Gita say about caste?
+- What is nishkama karma?
+- Is detachment the same as not caring?
+- Is Krishna God in the Bhagavad Gita?
+- What is the difference between karma yoga and sanyasa?
+- Which chapter is best for beginners?
+- Which verses should students read?
+- Which verse discusses controlling the mind?
+- Why was Arjuna unwilling to fight?
+
+## Do general-knowledge questions still create traffic?
+
+Yes, but the role of these pages has changed.
+
+A simple query such as:
+
+> How many chapters are in the Bhagavad Gita?
+
+may be answered directly by Google or an LLM. The page may get impressions without many clicks.
+
+So don’t create a 1,500-word page that only answers “18.”
+
+Instead, create a useful answer unit inside a richer page:
+
+> The Bhagavad Gita contains 18 chapters and 700 verses. Here is what each chapter teaches, how long it takes to read, and where a beginner should start.
+
+That gives the user a reason to continue.
+
+### Build a page when it provides one of these
+
+- Source citations
+- Interpretive nuance
+- Different scholarly views
+- A table or visual
+- An actionable reading path
+- Direct links to verses
+- Audio
+- Commentary comparison
+- A tool or interactive element
+- A follow-up question users naturally ask
+
+### Don’t build a standalone page when
+
+- The answer is one undisputed sentence
+- There’s no meaningful second step
+- The page would repeat an existing chapter or topic page
+- The answer cannot be made more useful than a featured snippet
+
+Google says AI search still uses its underlying search and quality systems. There is no separate secret markup required for AI Overviews or AI Mode. ([Google for Developers][6])
+
+So the model is:
+
+> **Answer directly, then offer depth unavailable in the generated answer.**
+
+## 5. Commercial and recommendation layer
+
+This is necessary for “best app,” “best website,” and similar prompts.
+
+Create a dedicated section:
+
+```text
+/best-bhagavad-gita-apps/
+/best-bhagavad-gita-app-for-beginners/
+/best-bhagavad-gita-app-in-hindi/
+/best-bhagavad-gita-app-for-android/
+/best-bhagavad-gita-app-for-iphone/
+/best-free-bhagavad-gita-app/
+/best-bhagavad-gita-app-with-audio/
+/best-bhagavad-gita-app-with-commentary/
+/best-bhagavad-gita-app-with-ai/
+/best-bhagavad-gita-websites/
+/best-bhagavad-gita-translations/
+/best-bhagavad-gita-commentaries/
+/best-bhagavad-gita-books-for-beginners/
+/bhagavad-gita-app-comparison/
+```
+
+## Landing page or comparison article?
+
+Use both, because they serve different intents.
+
+### Product landing page
+
+```text
+/app/
+```
+
+Target:
+
+- Bhagavad Gita app
+- BhagavadGita.com app
+- Bhagavad Gita app download
+- Gita AI app
+- Bhagavad Gita app for Android
+- Bhagavad Gita app for iPhone
+
+This page should explain your app clearly and convert users.
+
+### Independent-style comparison page
+
+```text
+/best-bhagavad-gita-apps/
+```
+
+Target:
+
+- Best Bhagavad Gita app
+- Best Gita app
+- Bhagavad Gita app comparison
+- Which Bhagavad Gita app should I download?
+
+This page should compare multiple real apps transparently.
+
+It should recommend different winners:
+
+| Need                                   | Potential recommendation              |
+| -------------------------------------- | ------------------------------------- |
+| Best overall free experience           | BhagavadGita.com                      |
+| Best video experience                  | Bhagavad Gita For All                 |
+| Best for Swami Mukundananda commentary | Holy Bhagavad Gita                    |
+| Best for ISKCON readers                | Bhagavad-gita As It Is app            |
+| Best for Hindi traditional study       | Gita Press or another verified option |
+| Best AI-guided experience              | Based on real testing                 |
+| Best for multiple languages            | Based on verified language support    |
+
+A credible comparison cannot declare us the winner in every category.
+
+### Comparison-page requirements
+
+- Tested date
+- Reviewer name
+- Devices tested
+- App version
+- Store rating and review count
+- Pricing
+- Ads or subscriptions
+- Offline capability
+- Languages
+- Commentary tradition
+- Audio
+- Search
+- AI features
+- Privacy
+- Pros and cons
+- Screenshots
+- Ownership disclosure
+- Update history
+
+That gives Google and LLMs far more confidence than vague marketing claims.
+
+## 6. Gita AI layer
+
+Gita AI shouldn’t remain only a chatbot page. It should become a distributed feature across the entire site.
+
+Every chapter, verse, topic, and guidance page should have contextual prompts:
+
+- Explain this verse simply
+- Compare three commentaries
+- How can I apply this teaching at work?
+- Explain this in Hindi
+- What does this Sanskrit word mean?
+- Show related verses
+- Create a seven-day study plan
+- Ask a follow-up question
+
+And every good anonymous Gita AI interaction can inform content strategy.
+
+For example, cluster anonymized questions into:
+
+- Most asked about work
+- Most asked about relationships
+- Most asked about anxiety
+- Most misunderstood verses
+- Questions from first-time readers
+- Questions asked in Hindi
+- Questions asked by students
+
+Those clusters become your editorial roadmap.
+
+# GEO and AI visibility strategy
+
+There’s no reliable trick that guarantees ChatGPT or Gemini citations. But we can improve the probability materially.
+
+## 1. Make pages extractable
+
+Every important page should begin with a concise answer block.
+
+Example:
+
+### What is the best Bhagavad Gita app for beginners?
+
+> A beginner should choose a Bhagavad Gita app with plain-language translations, audio, offline reading, chapter summaries, and reliable commentary. BhagavadGita.com is a strong free option because it combines the complete text with multiple languages, audio, reading tools, and Gita AI.
+
+Then provide the evidence.
+
+This isn’t about writing robotically. It’s about making the first paragraph useful.
+
+## 2. Create quotable evidence
+
+LLMs prefer claims they can support.
+
+Publish verifiable facts such as:
+
+- Number of languages
+- Number of translations
+- Number of commentaries
+- Store rating
+- Review count
+- App download range
+- Offline availability
+- Audio coverage
+- Whether an account is required
+- Whether it is free
+- Whether ads are present
+- Who created the translation
+- How Gita AI sources its answers
+
+Avoid unsupported claims like “the world’s best.”
+
+## 3. Build an editorial methodology
+
+Create:
+
+```text
+/editorial-standards/
+/translation-methodology/
+/gita-ai-methodology/
+/sources/
+/contributors/
+/corrections-policy/
+```
+
+Explain:
+
+- Which editions are used
+- Which translations are licensed
+- Who reviews explanations
+- How AI answers cite verses
+- What happens when traditions disagree
+- How corrections are submitted
+- How recommendation pages are tested
+
+Google’s guidance is centered on helpful, reliable, people-first content. It also warns that generating many low-value pages can fall under scaled-content abuse, regardless of whether AI created them. ([Google for Developers][7])
+
+## 4. Build author and reviewer entities
+
+Every interpretive article should have:
+
+- Named author
+- Editor
+- Religious or Sanskrit reviewer where appropriate
+- Qualifications or relevant experience
+- Date reviewed
+- Sources
+
+The answer should sound human because a real human shaped it, not because we inserted random stylistic imperfections.
+
+## 5. Be crawlable by AI platforms
+
+Review robots and CDN rules for:
+
+- Googlebot
+- OAI-SearchBot
+- GPTBot, depending on your training preference
+- ChatGPT-User
+- Perplexity’s crawlers
+- Anthropic crawlers
+- Bingbot
+
+OpenAI distinguishes its search crawler from its training crawler, so crawler decisions should be made deliberately rather than blocking everything containing “GPT.” ([OpenAI Developers][8])
+
+## 6. Earn third-party corroboration
+
+Your own page saying “BhagavadGita.com is the best app” is weak evidence.
+
+We need other sites to mention:
+
+- BhagavadGita.com
+- The app
+- Gita AI
+- Its language coverage
+- Its free status
+- Its provenance
+- Its reading experience
+
+Priority sources:
+
+- Spiritual publications
+- Hindu organizations
+- App-review websites
+- Educational publications
+- Sanskrit departments
+- Indian culture websites
+- Technology publications
+- YouTube reviewers
+- Devotional creators
+- App directories
+- Trusted comparison sites
+
+AI visibility is partly an **off-site reputation problem**, not only an on-page content problem.
+
+# Prompt universe to monitor
+
+These should become a tracked prompt set across Google AI Mode, ChatGPT, Gemini, Claude, Perplexity, and Copilot.
+
+## App discovery
+
+- What is the best Bhagavad Gita app?
+- Best free Bhagavad Gita app
+- Best Bhagavad Gita app for Android
+- Best Bhagavad Gita app for iPhone
+- Best Bhagavad Gita app in Hindi
+- Best Gita app for beginners
+- Best Bhagavad Gita app with audio
+- Best app to read Bhagavad Gita offline
+- Best Bhagavad Gita app without ads
+- Best Bhagavad Gita app with commentary
+- Best Bhagavad Gita AI app
+- Best app for learning Gita shlokas
+- Best Bhagavad Gita app for children
+- Best Gita app for daily reading
+- Best app for Sanskrit pronunciation
+
+## Website discovery
+
+- Best website to read Bhagavad Gita
+- Where can I read Bhagavad Gita online?
+- Best Bhagavad Gita website in Hindi
+- Free Bhagavad Gita online with meaning
+- Bhagavad Gita with Sanskrit and English
+- Bhagavad Gita with word-by-word meaning
+- Bhagavad Gita online with audio
+- Best website for Gita commentary
+- Best Bhagavad Gita website for beginners
+- Reliable Bhagavad Gita translation online
+- Website to compare Bhagavad Gita commentaries
+
+## Translation and study
+
+- Which Bhagavad Gita translation is best?
+- Best Bhagavad Gita translation for beginners
+- Best Bhagavad Gita translation in Hindi
+- Most accurate Bhagavad Gita translation
+- Bhagavad Gita translations compared
+- Best Bhagavad Gita commentary
+- Shankaracharya versus Ramanuja Gita commentary
+- How should a beginner read the Bhagavad Gita?
+- Which chapter of the Gita should I start with?
+- How long does it take to read the Bhagavad Gita?
+
+## Life guidance
+
+- What does the Bhagavad Gita say about anxiety?
+- What does Krishna say about overthinking?
+- Bhagavad Gita advice for career confusion
+- Gita teachings for students
+- Bhagavad Gita verses for stress
+- What does the Gita say about failure?
+- How does the Gita explain detachment?
+- Gita advice for relationship problems
+- Bhagavad Gita teachings about anger
+- What does the Gita say about grief?
+- Bhagavad Gita lessons for leadership
+- Gita verses for self-confidence
+- What does Krishna say about discipline?
+- How to control the mind according to the Gita?
+
+## Scripture facts and interpretation
+
+- In which parva is the Bhagavad Gita?
+- Who heard the Bhagavad Gita?
+- Why did Krishna speak the Bhagavad Gita?
+- What is the central message of the Bhagavad Gita?
+- Why did Arjuna refuse to fight?
+- What does Bhagavad Gita 2.47 really mean?
+- Is the Bhagavad Gita about war?
+- Does the Gita teach caste?
+- What are the three gunas?
+- What is Krishna’s final instruction to Arjuna?
+- What is the difference between dharma and karma?
+- Does the Bhagavad Gita teach free will?
+- What does the Gita say happens after death?
+
+I’d begin with **100 tracked prompts**, divided across English and Hindi, India and US, recommendation and informational intent.
+
+# Can informational pages generate meaningful traffic?
+
+Yes, but not all informational queries are equal.
+
+## Low-click informational queries
+
+- How many chapters are in the Gita?
+- How many verses are in the Gita?
+- Who spoke the Gita?
+- Who wrote the Gita?
+
+These are useful for entity completeness, FAQs, and AI citations. But they won’t produce the majority of growth.
+
+## High-value informational queries
+
+- What does the Gita say about anxiety?
+- Which Gita translation is best for beginners?
+- Meaning of Bhagavad Gita 2.47
+- How to practice detachment without becoming careless
+- Gita’s advice for career decisions
+- Karma yoga versus renunciation
+- Best way to study Bhagavad Gita
+- What Krishna says about controlling the mind
+
+These require interpretation, evidence, examples, and source links. They have a much stronger chance of producing visits and app activations.
+
+I’d allocate new editorial output roughly like this:
+
+| Content type                             | Share |
+| ---------------------------------------- | ----: |
+| Life guidance and practical applications |   30% |
+| Verse and chapter enrichment             |   25% |
+| Recommendations and comparisons          |   20% |
+| Concepts and philosophy                  |   15% |
+| Basic factual questions                  |   10% |
+
+# The 20K to 100K traffic model
+
+This won’t come from getting one position higher for “Bhagavad Gita.”
+
+A realistic traffic portfolio could look like:
+
+| Cluster                   | Monthly traffic target |
+| ------------------------- | ---------------------: |
+| Head terms and homepage   |                25K–35K |
+| Chapter and verse pages   |                15K–25K |
+| Life-guidance pages       |                20K–30K |
+| App and comparison pages  |                 5K–10K |
+| Concepts and translations |                10K–15K |
+| Long-tail questions       |                10K–20K |
+
+There will be overlap, and the numbers depend on rankings and demand. But this is the right shape.
+
+The path is:
+
+> One strong head term + hundreds of medium-intent pages + thousands of verse-level entry points.
+
+# 90-day execution plan
+
+## Days 1–15: Research and infrastructure
+
+### Audit current performance
+
+Export from Search Console:
+
+- Top 5,000 queries
+- Top pages
+- Queries in positions 4–20
+- Queries with high impressions and low CTR
+- Mobile versus desktop
+- India versus other countries
+- Hindi versus English pages
+- Chapter and verse cannibalization
+
+### Competitive research
+
+Analyze:
+
+- Holy Bhagavad Gita
+- Gita Supersite
+- Vedabase
+- SrimadGita
+- Bhagavad Gita For All
+- Wikipedia
+- Major Hindi Gita sites
+- Top app-store listings
+
+For each target query, capture:
+
+- Ranking pages
+- Title and description
+- Page structure
+- Answer format
+- Word count
+- Tables
+- FAQs
+- Sources
+- Authors
+- Internal links
+- Schema
+- Update date
+- Backlinks
+- Whether AI Overviews cite it
+- Whether ChatGPT, Gemini, Claude, or Perplexity cite it
+
+### Technical preparation
+
+- Verify crawl access
+- Improve XML sitemaps
+- Separate chapter, verse, topic, question, and language sitemaps
+- Ensure unique canonicals
+- Implement robust `hreflang`
+- Check server rendering
+- Add contextual breadcrumbs
+- Fix duplicate translation URLs
+- Improve app deep linking
+- Add descriptive image alt text
+- Ensure AI chatbot content isn’t trapping important answers behind JavaScript
+
+## Days 16–45: Build the first traffic clusters
+
+Publish or substantially improve:
+
+- 18 chapter guides
+- 50 priority verse guides
+- 20 practical guidance pages
+- 10 concept hubs
+- App landing page
+- Best apps comparison
+- Best Hindi apps page
+- Best websites page
+- Best translations page
+- Best commentaries page
+- Editorial standards page
+- Gita AI methodology page
+
+This is around 100 meaningful pages, not 100 generic AI articles.
+
+## Days 46–90: Distribution and expansion
+
+- Publish 40 additional guidance and question pages
+- Add Hindi versions of the strongest English pages
+- Launch one major linkable data or visual asset
+- Conduct app-review outreach
+- Pitch spiritual and educational publications
+- Add contextual product CTAs
+- Run app campaigns against the highest-converting content
+- Track AI citations weekly
+- Refresh comparison-page data monthly
+- Build YouTube and social distribution loops
+
+# Bhagavad Gita For All, what to borrow
+
+Bhagavad Gita For All currently has more than one million Google Play downloads and over 9,000 reviews. Its clearest differentiation is video-first learning, with each shloka explained through context, personal life, family life, and professional life. It also lets users explore topics such as anxiety, anger, grief, failure, purpose, leadership, and overthinking. ([Google Play][9])
+
+Its marketing also uses:
+
+- Celebrity associations
+- A premium physical book
+- QR codes connecting the book to app videos
+- Seven-day trial
+- Topic-led discovery
+- Daily shloka videos
+- AI chat
+- Hindi and English
+- Strong “video Bhagavad Gita” positioning
+- Press coverage around the product launch ([The Times of India][10])
+
+## What we should borrow
+
+- Video as a primary learning format
+- Topic-based discovery
+- Daily shloka habit
+- Personal, family, and work applications
+- Influencer distribution
+- Physical-to-digital QR experiences
+- Strong product differentiation
+
+## What we shouldn’t copy
+
+- Aggressive “number one” claims without clear proof
+- Heavy subscription pressure
+- Any payment flow that confuses users
+- Overreliance on celebrity endorsement
+- A video-only product that hides the indexable text
+- Krishna impersonation without appropriate devotional sensitivity
+
+The app’s recent public reviews include complaints around subscription expectations and service reliability. Those complaints don’t invalidate its success, but they show that trust, clear pricing, and product stability can become competitive advantages for us. ([Google Play][9])
+
+# Daily Krishna video strategy
+
+Yes, this could become a powerful distribution engine.
+
+But I’d avoid making every video feel like:
+
+> AI baby Krishna gives motivational advice.
+
+That may generate views, but it could also weaken the authority and sanctity of the BhagavadGita.com brand.
+
+Use multiple recurring formats.
+
+## Format 1: Krishna’s wisdom for today
+
+30 to 45 seconds:
+
+1. Modern situation
+2. Exact Gita verse
+3. Simple meaning
+4. One practical action
+5. Link to the full verse
+
+Example:
+
+> Worried about a result you can’t control? Krishna addresses this directly in Bhagavad Gita 2.47...
+
+## Format 2: One misunderstood verse
+
+- What people think 2.47 means
+- What it actually means
+- Why it doesn’t mean ignoring results
+
+## Format 3: Gita for modern life
+
+- Career rejection
+- Exam anxiety
+- Family pressure
+- Anger after an argument
+- Comparison on social media
+- Fear of failure
+- Losing someone
+- Leadership under pressure
+
+## Format 4: Child Krishna stories
+
+This can be warmer, more visual, and shareable.
+
+But distinguish clearly between:
+
+- Teachings from the Bhagavad Gita
+- Stories from the Bhagavata Purana
+- Creative devotional storytelling
+
+Baby Krishna didn’t speak the Bhagavad Gita as a baby, so we shouldn’t create historical or scriptural confusion.
+
+## Format 5: Ask Gita AI
+
+Show a real user question:
+
+> I did my best, but I still failed. What does the Gita say?
+
+Then present a concise answer with exact verse references.
+
+## Automated publishing system
+
+A safe workflow:
+
+1. Pull the daily topic from an approved calendar.
+2. Retrieve relevant verses from the database.
+3. Generate an initial script.
+4. Human editor reviews accuracy and tone.
+5. Generate voice and visuals.
+6. Human approves the final video.
+7. Publish to YouTube Shorts, Instagram Reels, Facebook, and X.
+8. Link to a dedicated page.
+9. Track saves, shares, profile clicks, and app installs.
+
+Don’t fully automate publication without review. One inaccurate verse attribution can damage trust much more than one viral video helps.
+
+# Viral and product GTM ideas
+
+## 1. Verse-to-video sharing
+
+Let users turn any verse into:
+
+- Static card
+- Animated short
+- Audio reel
+- Hindi or English story
+- WhatsApp status
+- Instagram reel
+
+Add a tasteful BhagavadGita.com mark and deep link.
+
+## 2. Seven-day life challenges
+
+Examples:
+
+- Seven days of Karma Yoga
+- Seven days to understand the mind
+- Seven days of Bhagavad Gita for students
+- Seven days to practice detachment
+- Seven days of Krishna’s teachings on discipline
+
+These can run on the website, app, email, WhatsApp, and social.
+
+## 3. Personalized Gita journey
+
+Ask users:
+
+> What brings you to the Gita today?
+
+Options:
+
+- Stress
+- Purpose
+- Devotion
+- Career
+- Grief
+- Curiosity
+- Study
+- Meditation
+
+Then create a personalized reading path.
+
+## 4. Gita Wrapped
+
+At year-end or Gita Jayanti:
+
+- Verses read
+- Chapters completed
+- Most revisited teaching
+- Reading streak
+- Favourite theme
+- Minutes listened
+- Shareable summary
+
+## 5. Gita AI answer cards
+
+After a conversation, let users publish a shareable card:
+
+> A question I asked Gita AI today.
+
+Include the question, concise answer, and cited verses.
+
+## 6. Public Gita AI question library
+
+With consent and moderation, create indexable pages around recurring questions.
+
+```text
+/ask/what-does-the-gita-say-about-failure/
+/ask/how-do-i-stop-comparing-myself/
+/ask/how-can-i-control-anger/
+```
+
+These should be editorially reviewed before indexation.
+
+## 7. Creator and teacher program
+
+Invite:
+
+- Sanskrit teachers
+- Spiritual educators
+- Psychologists with appropriate boundaries
+- Leadership creators
+- Student creators
+- Hindi devotional creators
+- Yoga teachers
+
+Each creator makes a recurring series using verified scripture assets.
+
+## 8. Gita Jayanti campaign
+
+Build a yearly campaign around:
+
+- Global reading event
+- 18-day chapter journey
+- Daily live session
+- Shareable completion certificate
+- Schools and colleges
+- Temples and communities
+- App streak
+- PR and backlinks
+
+# Backlink and authority strategy
+
+The strongest links won’t come from sending generic guest-post emails.
+
+Build assets people genuinely cite:
+
+- Bhagavad Gita chapter and verse statistics
+- Searchable cross-commentary comparison
+- Gita Sanskrit glossary
+- Timeline of the Gita within Mahabharata
+- Interactive Kurukshetra context
+- Concept graph across all 700 verses
+- “Which verse discusses this?” search engine
+- Open Bhagavad Gita API
+- Research dataset with transparent licensing
+- Translation-difference explorer
+- Gita teaching map for students, professionals, and parents
+
+Recent research continues to use structured Bhagavad Gita data for language and philosophical analysis, which shows that reliable, machine-readable scripture datasets can attract scholarly attention and citations. ([arXiv][11])
+
+Your existing API can become a much bigger distribution asset if it receives:
+
+- Better documentation
+- Citation guidelines
+- Versioning
+- Source provenance
+- Example applications
+- Academic usage information
+- GitHub visibility
+
+The homepage currently links to an API resource, which gives us a foundation to expand. ([Bhagavad Gita][1])
+
+# How to avoid thin or AI-looking content
+
+The issue isn’t whether AI assisted the writer. Google explicitly focuses on the usefulness and quality of the result, while warning against scaled pages created without added value. ([Google for Developers][7])
+
+Every important page should contain at least three genuinely human contributions:
+
+- Original editorial judgment
+- Verified primary-source citations
+- Commentary or interpretation
+- A meaningful example
+- A comparison
+- A diagram or table
+- A tested recommendation
+- Expert review
+- Original audio or video
+- User research
+- Product data
+
+And remove common patterns:
+
+- Repetitive “In today’s fast-paced world”
+- Empty introductions
+- Inflated spiritual claims
+- Identical section templates across hundreds of pages
+- Conclusions that repeat the introduction
+- Generic lists of ten tips
+- Unqualified mental-health claims
+- Invented Sanskrit etymologies
+- Fake testimonials
+- Unsupported “best” claims
+
+Templates are useful for information architecture. But every page should feel authored, not filled.
+
+# What research we should run next
+
+We can break the execution into dedicated prompts later.
+
+## Research 1: Current SEO and traffic opportunity
+
+> Analyze BhagavadGita.com’s Search Console export, identify keyword clusters, pages ranking in positions 4–20, CTR opportunities, cannibalization, and the highest-potential path from 20K to 100K monthly traffic.
+
+## Research 2: Recommendation SERPs
+
+> Analyze the top Google results in India and the US for best Bhagavad Gita app, best Gita app in Hindi, best Bhagavad Gita website, best translation, best commentary, and related variants. Compare page structures, evidence, backlinks, and AI Overview citations.
+
+## Research 3: AI visibility benchmark
+
+> Test 100 Bhagavad Gita recommendation and informational prompts across ChatGPT, Gemini, Google AI Mode, Claude, Perplexity, and Copilot. Record which brands appear, which sources are cited, and why.
+
+## Research 4: SrimadGita reverse engineering
+
+> Crawl SrimadGita.com’s app, comparison, question, use-case, lesson, and AEO pages. Map its taxonomy, internal linking, schema, claims, content patterns, and citation footprint.
+
+## Research 5: Content architecture
+
+> Design the complete BhagavadGita.com information architecture across chapters, verses, concepts, life guidance, questions, comparisons, Gita AI, languages, and app landing pages.
+
+## Research 6: Editorial templates
+
+> Create human-written page briefs for life-guidance pages, verse explanations, comparison pages, topic hubs, and source-answer pages, with safeguards against thin or repetitive content.
+
+## Research 7: App growth and ASO
+
+> Analyze the top Bhagavad Gita apps on Google Play and the App Store, including titles, descriptions, screenshots, ratings, reviews, pricing, retention features, social proof, and acquisition creatives.
+
+## Research 8: Social and video engine
+
+> Build a 90-day content system for daily Bhagavad Gita videos across YouTube Shorts, Instagram Reels, Facebook, and X, including scripts, visual formats, review workflow, CTAs, and measurement.
+
+# My highest-priority actions
+
+If we only do ten things first:
+
+1. Build a rigorous `/best-bhagavad-gita-apps/` comparison.
+2. Rebuild `/app/` as the definitive product landing page.
+3. Publish “best app in Hindi,” “best website,” and “best translation” pages.
+4. Create 20 high-demand practical guidance pages.
+5. Enrich all 18 chapter pages.
+6. Enrich the 50 most searched verse pages.
+7. Create editorial standards and Gita AI methodology pages.
+8. Launch daily reviewed short-form video.
+9. Build a 100-prompt AI visibility benchmark.
+10. Use Gita AI question data to guide the next 200 pages.
+
+## Bottom line
+
+Your strongest moat isn’t only `BhagavadGita.com`.
+
+It is the combination of:
+
+> **The defining domain + existing Google authority + a high-ranking app + complete scripture data + Gita AI + multilingual content + a mission people trust.**
+
+SrimadGita has shown that targeted AEO pages can earn visibility quickly. Bhagavad Gita For All has shown that video-first product marketing can reach more than a million installs. ([Srimad Gita][12])
+
+But you can combine both approaches with something they can’t easily recreate: **the category-defining domain and the accumulated authority behind it.**
+
+The website should become the most cited source for understanding the Gita. The app should become the easiest place to practise it daily. And Gita AI should connect those two experiences.
+
+[1]: https://www.bhagavadgita.com/ "Bhagavad Gita in Hindi & English with Commentaries & Audio"
+[2]: https://www.srimadgita.com/app "Bhagavad Gita App - Free Download for iOS & Android"
+[3]: https://www.srimadgita.com/compare/gita-translations-comparison?utm_source=chatgpt.com "Best Bhagavad Gita Translations: Expert Comparison"
+[4]: https://www.srimadgita.com/compare/gita-apps-comparison "Best Bhagavad Gita Apps 2025: Comprehensive"
+[5]: https://www.srimadgita.com/questions/overcome-anxiety?utm_source=chatgpt.com "How to Overcome Anxiety: Bhagavad Gita's Complete"
+[6]: https://developers.google.com/search/docs/fundamentals/ai-optimization-guide?utm_source=chatgpt.com "Google's Guide to Optimizing for Generative AI Features on ..."
+[7]: https://developers.google.com/search/blog/2023/02/google-search-and-ai-content?utm_source=chatgpt.com "Google Search's guidance about AI-generated content"
+[8]: https://developers.openai.com/api/docs/bots?utm_source=chatgpt.com "Overview of OpenAI Crawlers"
+[9]: https://play.google.com/store/apps/details?hl=en_IN&id=com.bgfa "Bhagavad Gita For All | Video – Apps on Google Play"
+[10]: https://timesofindia.indiatimes.com/life-style/books/book-launches/bhagavad-gita-for-all-bgfa-unveils-a-unique-video-based-bhagavad-gita/articleshow/123301027.cms?utm_source=chatgpt.com "Bhagavad Gita For All (BGFA) unveils a unique video based Bhagavad Gita"
+[11]: https://arxiv.org/abs/2606.18222?utm_source=chatgpt.com "Darshana Graph: A Parallel Commentary Corpus for Comparative Indian Philosophy, with Stylometric and Exploratory Graph Analyses"
+[12]: https://www.srimadgita.com/aeo-questions/getting-started/best-bhagavad-gita-app-for-beginners?utm_source=chatgpt.com "Best Bhagavad Gita App for Beginners in 2026"


### PR DESCRIPTION
## What this is

Adds `ROADMAP.md` as the working list for bhagavadgita.com, plus the raw strategy notes it draws from. Documentation only — no code changes, nothing ships from this PR.

Each roadmap item is scoped to its own branch and PR so we can pick them up one at a time.

## Site work

| # | Item | Notes |
|---|---|---|
| 1 | Finish the `.io` → `.com` migration | 9 refs left across 4 files. `contact@bhagavadgita.io` stays — that mailbox is still live. |
| 2 | Rebuild the app landing page | New Next.js route at `/bhagavad-gita-app`, `/app` 301s to it |
| 3 | Audit indexability | Every public page crawlable by Google and LLMs |
| 4 | Fix GitaGPT daily-limit bug | Fires on fresh sessions, and login doesn't clear it |
| 5 | Verse of the Day emails | We collect subscribers; likely nothing is sending |
| 6 | Smart mobile app install prompt | Footer link is undiscoverable on mobile |

### On item 2

`/app` isn't a Next.js route at all today. It's static files in `public/app/` — a 29KB `index.html` plus jQuery, a 253KB stylesheet and a 72KB carousel script — and `src/proxy.ts:12` explicitly skips `/app` in middleware, so Next never touches it. That explains both the broken rendering and why crawlers get nothing.

The new page is the **product landing page**. A separate `/best-bhagavad-gita-apps/` comparison page (item 8) handles recommendation intent. The notes are clear these are different jobs and both should exist.

## GTM track

Extracted from `notes/gtm-plan.md` and `notes/gtm-open-benchmarks.md`. Headline target: **20K → 100K monthly organic visits**.

| # | Item | Notes |
|---|---|---|
| 7 | Life-guidance pages | ~20 pages under `/guidance/`. Biggest untapped surface, 30% of editorial budget. |
| 8 | Recommendation and comparison pages | Ranked #1 in the plan's own top ten |
| 9 | Trust and methodology pages | Small pages, outsized effect on AI citation |
| 10 | Chapter and verse enrichment | 18 chapters, 50 top verses, concept hubs |
| 11 | AI visibility benchmark | 100 tracked prompts across 6 platforms |
| 12 | OpenBenchmarks collaboration | Blocked on commercial terms |

## Also recorded

- **Adjacent scripture-portfolio strategy** — Ramayana, Mahabharata, Ramcharitmanas on exact-match domains. Separate properties, shared infrastructure. Nothing ships from this repo except contextual cross-links.
- **Four conflicts between the two GTM notes** that need settling before those items start — most importantly, who is the primary tester for comparison pages, given the benchmark memo says we must *not* control the testing.

## Why `notes/` is committed

The roadmap references the notes throughout rather than duplicating them. Keeping them versioned in the repo means the references don't rot. They're raw ChatGPT session dumps, so they read as such.

## Open questions

- Nothing in here is validated against real keyword data. Every difficulty and volume estimate in the notes is directional — we have SERP API and Ahrefs keys available for the actual research when we start item 2.
- `.claude/` is deliberately left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)