### PR TITLE
docs: email provider research and roadmap restructure

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,17 +22,8 @@ in four files:
 - `src/app/copyright/[[...locale]]/page.tsx`
 - `src/components/Footers/Footer.tsx`
 
-**Important exception:** the contact address stays `contact@bhagavadgita.io`. That mailbox is
-still live on the old domain, so leave every `mailto:` and any email string alone. Only swap
-web URLs.
-
-Also worth checking while we're in here:
-
-- canonical tags, `metadataBase`, Open Graph and Twitter URLs
-- `sitemap.ts` and `robots.txt` output
-- structured data (`@id`, `url`, `sameAs`)
-- anything hardcoded in `public/app/index.html`, `manifest.json`, and the Supabase config
-- redirects in `vercel.json` — confirm .io still 301s to .com so we don't drop link equity
+The contact address stays `contact@bhagavadgita.io`. That mailbox is still live on the old
+domain, so leave every `mailto:` alone if this is ever revisited.
 
 ---
 
@@ -130,71 +121,86 @@ The anonymous allowance went from 2 to 5; signed-in stays at 10. Limits are cent
 
 ---
 
-## 5. Fix the newsletter capture, then build Verse of the Day emails
+## 5. Verse of the Day emails
 
-**Status:** in progress — PR for items 5 and 6 open
-**Branch:** `fix/newsletter-and-attribution`
+**Status:** capture done (PR #301). Sending deferred until the list is worth sending to.
 
-**The subscription form has never saved anything.** Confirmed against production on
-2026-07-20:
+### 5a. Capture — done
 
-```
-GET /rest/v1/newsletter_subscriptions
-404  {"code":"42P01","message":"relation \"public.newsletter_subscriptions\" does not exist"}
-```
+The subscription form had never saved anything. Three independent faults, any one of which
+alone would have lost every submission:
 
-Seven plausible table names all return 404, and no migration in `supabase/migrations/` ever
-created one. The three migrations present are pgvector, hybrid search and chat history.
+1. `subscribeUser` read `NEXT_PUBLIC_SUPABASE_ANON_KEY`, which has never existed in this
+   project. It returned before reaching the database.
+2. The `newsletter_subscriptions` table did not exist and no migration ever created it.
+3. After fixing both, `.insert().select()` still failed with `42501`. PostgREST needs SELECT
+   permission to return an inserted row, and anonymous callers deliberately have none on this
+   table.
 
-There were two independent faults, either of which alone would have lost every
-submission. `subscribeUser` read `NEXT_PUBLIC_SUPABASE_ANON_KEY`, which has never existed in
-this project (the key is `NEXT_PUBLIC_SUPABASE_KEY`), so it returned before reaching the
-database. And the table did not exist anyway.
+And it failed silently: the helper caught its own error and returned `null` rather than
+throwing, so the form's `catch` never ran and everyone saw a success modal regardless.
 
-It fails silently, and the user is told it worked. `src/lib/subscribeUser.ts` catches its own
-error and returns `null` rather than throwing, so the `catch` in
-`src/components/Home/Newsletter.tsx:87` never runs. Execution continues to
-`setModalVisible(true)` and returns `isSuccess: true`. Everyone who ever submitted that form
-saw a confirmation and nothing was stored.
+Verified live on production: valid address writes a row, duplicate returns 23505 and reads as
+success, invalid and empty input are blocked client-side with zero writes.
 
-So this item is not "we collected emails but never sent them". It is "we collected nothing and
-said we did". Order of work:
+### 5b. Sending — not started
 
-1. Create the table with a migration, with a unique constraint on email.
-2. Make `subscribeUser` propagate failures so the form can show a real error. A silent
-   `return null` on a write path is the actual bug here, and it will hide the next one too.
-3. Only then build the send: Resend or Loops, a Vercel cron, a branded template, one-click
-   unsubscribe, delivery logging.
+**Provider decision: Resend, on the Broadcasts path.** Full comparison against Loops and AWS
+SES in `notes/email-provider-research.md`. Short version: Loops is disqualified because its
+transactional surface forbids marketing content and its campaign surface is not cleanly
+API-drivable; SES saves only about $1,500 a year even at 36,000 subscribers, against three to
+five days of build and permanent ownership of deliverability.
 
-Note we do already hold roughly 36,000 emails in Supabase auth from people who signed up for
-Gita GPT. Those are not newsletter subscribers and must not be treated as opted in, but they
-are the reason item 6 below matters.
+Note React Email is **not** a reason to pick Resend. It renders to plain HTML and works with
+SES too. What Resend buys is the compliance layer: RFC 8058 one-click unsubscribe, suppression,
+bounce and complaint webhooks, and a dashboard showing whether the send went out.
+
+To build:
+
+- A **welcome email on subscribe**, confirming they are on the list and setting expectations
+  for what arrives and when. This should go out the moment someone submits the form or ticks
+  the opt-in at signup, not with the first daily send.
+- The daily send itself: Vercel cron, Resend Broadcast, branded template
+- One-click unsubscribe honoured within 48 hours, writing to `unsubscribed_at`
+- Seven-language templates with per-script font stacks, tested in real Gmail, Apple Mail and
+  Outlook before launch
+- Everything behind a single `sendDailyVerse()` module so SES stays a swap rather than a rewrite
+
+Blocked on item 6b: there is not yet a list large enough to justify the work.
 
 ---
 
 ## 6. Signup attribution and funnel instrumentation
 
-**Status:** in progress — same PR as item 5
-**Branch:** `fix/newsletter-and-attribution`
+**Status:** 6a shipped in PR #301 and needs live verification. 6b not started.
 
-We have about 36,000 users in Supabase auth and no way to tell where any of them came from.
-The Gita GPT limit banner is a sign-in prompt, so a large share of them probably hit the
-anonymous wall and signed up there, but that is an assumption we cannot currently check.
+### 6a. Attribution — shipped, unverified
 
-Capture, at minimum:
+`signup_attribution` records the source, the path, and whether the Gita GPT limit banner was on
+screen at signup. All six `AuthModal` call sites pass a source; the chat surfaces distinguish
+`gitagpt_rate_limit` from plain `gitagpt`. There is no update policy on the table on purpose,
+since attribution should not be rewritable after the fact.
 
-- signup source: Gita GPT limit wall, Gita GPT page, newsletter form, direct, or another page
-- the page path the signup happened on
-- whether the user had hit the rate limit immediately before signing up
-- newsletter opt-in as an explicit separate flag, not inferred from having an account
+Still to check on production: sign up fresh from the limit banner and confirm the row records
+`signup_source = 'gitagpt_rate_limit'` with `hit_rate_limit_before_signup = true`. This is the
+number that will eventually say whether raising the anonymous allowance from 2 to 5 was right.
 
-Without this we cannot say whether the anonymous allowance is converting, which is the open
-question behind item 4's limit change (2/day to 5/day). The limits live in
-`src/lib/rate-limit-config.ts` and are trivial to tune once there is data to tune against.
+### 6b. In-app opt-in for existing users — not started
 
-Also worth verifying end to end while in here: that Gita GPT conversations persist correctly,
-that the newsletter path works once item 5 lands, and that each has enough context recorded to
-tell what is working.
+We hold roughly 36,000 authenticated users. **They must not be bulk-imported into the mailing
+list.** They authenticated with Google or Apple to use Gita GPT and were never asked about
+email, so under the DPDP Act there is no consent for this purpose. More practically, sending to
+36,000 cold addresses from a domain with no sending history would produce high bounces and a
+complaint rate well past Gmail's 0.3% threshold, throttling the domain and stopping delivery
+for the people who genuinely did opt in.
+
+Instead, ask them inside the product: a dismissible one-time prompt for signed-in users, on top
+of the signup checkbox already shipped. Zero deliverability risk, and everyone who says yes is
+genuinely engaged.
+
+Realistic conversion is 10 to 30 per cent over time, so 4,000 to 11,000 subscribers rather than
+36,000. **This is the unblocker for item 5b** — it is what turns existing users into a list
+worth building a send for.
 
 ---
 

--- a/notes/email-provider-research.md
+++ b/notes/email-provider-research.md
@@ -1,0 +1,118 @@
+# Email provider research: Resend vs Loops vs AWS SES
+
+Researched 2026-07-20 for the Verse of the Day daily send (roadmap item 5b).
+
+**Decision: Resend, when we build it. Deferred until the list is large enough to be
+worth sending to.**
+
+---
+
+## The framing correction
+
+The daily verse is **not transactional**, despite feeling like it. A recurring email to a
+subscribed list is marketing-class content. It legally requires an unsubscribe link, and at
+any real volume we are a "bulk sender" under Gmail and Yahoo rules, so RFC 8058 one-click
+unsubscribe is mandatory. That single distinction decides most of this comparison.
+
+---
+
+## Loops is disqualified, on product fit rather than price
+
+Their own documentation says transactional emails have no unsubscribe links, no tracking, and
+that unsubscribed contacts still receive them, followed by "Marketing content shouldn't be
+sent this way." So the daily verse cannot go down that path.
+
+The correct Loops surface is Campaigns, but the Campaigns API creates **drafts only**, with no
+documented draft-to-send endpoint. Automating "create campaign, inject today's verse in seven
+languages, publish" every day means fighting the product forever. Loops is built for a
+marketer clicking Send, not a cron job.
+
+---
+
+## Pricing at realistic list sizes
+
+Resend now runs **both** pricing models: the transactional Emails API is per-email, and
+Broadcasts/Marketing is per-contact with no stated volume cap. The contact-pricing advantage
+that used to be Loops' moat is available inside Resend. Use Broadcasts, not the transactional
+API: at ~18k subscribers that is roughly $180/month against $350/month for identical volume.
+
+| Subscribers | Emails/month | Resend Broadcasts | AWS SES | Saving per year |
+| ----------- | ------------ | ----------------- | ------- | --------------- |
+| 5,000       | 150K         | $40               | ~$15    | $300            |
+| 10,000      | 300K         | $80               | ~$30    | $600            |
+| 20,000      | 600K         | $180              | ~$75    | $1,260          |
+| 36,000      | 1.08M        | $250              | ~$123   | $1,524          |
+
+SES is $0.10 per 1,000 emails, plus $15/month for managed dedicated IPs, which handle per-ISP
+warm-up automatically.
+
+**Even at 36,000 subscribers the saving is about $1,500 a year**, against three to five days of
+build plus permanent ownership of deliverability. At the list size we will realistically reach
+first, it is $300 to $600 a year. Not a good trade for a small team.
+
+---
+
+## What Resend actually buys us
+
+Not templates. **React Email renders to plain HTML and works with SES too**, so it is not a
+reason to choose Resend, and templating was SES's old weak point rather than a current one.
+
+What we are paying for is the compliance and operations layer:
+
+- RFC 8058 one-click unsubscribe headers, injected automatically on Broadcasts
+- Suppression list handling
+- Bounce and complaint webhooks
+- A dashboard that tells us whether today's send actually went out
+
+On SES every one of those is ours to build and own forever.
+
+---
+
+## Revisit SES when
+
+The list passes roughly 50,000 genuinely engaged subscribers, or if AWS non-profit credits
+come through. Build the send behind a single `sendDailyVerse()` module so the swap is days
+rather than a rewrite.
+
+---
+
+## Open questions before we commit money
+
+1. **Ask Resend two things.** Is 30 broadcasts a month to a large audience within the Marketing
+   plan's "no email volume limits"? And do they offer non-profit or open-source pricing? Ved
+   Vyas Foundation is a registered non-profit running an open-source project, which is a strong
+   case. Both answers could move the numbers.
+2. **Indic script rendering is untested and no vendor documents it.** All three send standard
+   UTF-8, so rendering depends on our font stack and the recipient's client. Outlook desktop
+   has historically had complex-script shaping bugs. Send real test renders to Gmail, Apple
+   Mail and Outlook before launch, and avoid webfonts for Indic scripts.
+3. **Data residency.** Resend stores account data, metadata and logs in the US regardless of
+   sending region, and none of the three has an India region. Check whether the foundation has
+   any DPDP Act obligation on subscriber emails.
+
+---
+
+## Why we are not importing the 36,000 existing auth users
+
+See roadmap item 6b. Short version: they authenticated to use Gita GPT and were never asked
+about email, so under the DPDP Act there is no consent for this purpose. More practically,
+sending to 36,000 cold addresses from a domain with no sending history would produce high
+bounces and a complaint rate well past Gmail's 0.3% threshold, getting the domain throttled.
+That would stop delivery for the people who genuinely did opt in. The list is worth more than
+the blast.
+
+---
+
+## Sources
+
+- https://resend.com/pricing
+- https://resend.com/docs/api-reference/emails/send-batch-emails
+- https://resend.com/blog/broadcast-api
+- https://loops.so/docs/transactional
+- https://loops.so/docs/api-reference/create-campaign
+- https://aws.amazon.com/ses/pricing/
+- https://docs.aws.amazon.com/ses/latest/dg/managed-dedicated-sending.html
+- https://datatracker.ietf.org/doc/html/rfc8058
+
+Loops tier prices ($49 at 5k contacts, $249 at 50k) are third-party sourced. Their pricing
+page is a JavaScript slider that could not be read directly.


### PR DESCRIPTION
Documentation only. Saves the email provider research and reorganises items 5 and 6 around what is actually done versus blocked.

## Provider decision: Resend, on the Broadcasts path

Full comparison in `notes/email-provider-research.md`.

**Loops is disqualified on product fit, not price.** Its own docs say transactional emails have no unsubscribe links and that "Marketing content shouldn't be sent this way", while its Campaigns API creates **drafts only** with no documented send endpoint. A daily verse is marketing-class content that needs an unsubscribe, so neither surface fits.

**SES saves less than it looks like it should:**

| Subscribers | Emails/mo | Resend Broadcasts | AWS SES | Saving/yr |
|---|---|---|---|---|
| 5,000 | 150K | $40 | ~$15 | $300 |
| 10,000 | 300K | $80 | ~$30 | $600 |
| 20,000 | 600K | $180 | ~$75 | $1,260 |
| 36,000 | 1.08M | $250 | ~$123 | $1,524 |

Even at 36,000 that is ~$1,500/year against three to five days of build plus permanent ownership of deliverability, quota ramps and suppression.

**Correction worth recording:** React Email is *not* a reason to pick Resend. It renders to plain HTML and works with SES too. What Resend actually buys is the compliance layer — RFC 8058 one-click unsubscribe, suppression, bounce webhooks, and a dashboard showing whether the send went out.

## Roadmap restructure

- **5a capture — done.** All three faults recorded. The third only surfaced by testing against production after the migration: `.insert().select()` fails with `42501` because PostgREST needs SELECT permission to return a row and anonymous callers deliberately have none.
- **5b sending — scoped, not started.** Now includes a **welcome email on subscribe**, sent the moment someone joins rather than waiting for the first daily send.
- **6a attribution — shipped, unverified.** Needs one live signup from the Gita GPT limit banner to confirm.
- **6b in-app opt-in — new, and the unblocker for 5b.**

## Why the 36,000 are not being imported

They authenticated with Google or Apple to use Gita GPT and were never asked about email, so there is no consent for this purpose under the DPDP Act. More practically, sending to 36,000 cold addresses from a domain with no sending history would produce high bounces and a complaint rate well past Gmail's 0.3% threshold, throttling the domain and **stopping delivery for the people who genuinely did opt in**.

The alternative is an in-app prompt for signed-in users. Realistic conversion is 10–30%, so 4,000–11,000 engaged subscribers rather than 36,000 unengaged ones.

## Open questions before spending money

1. Ask Resend whether 30 broadcasts/month to a large audience is within the Marketing plan's "no email volume limits", and whether they offer non-profit pricing. Ved Vyas Foundation is a registered non-profit running an open-source project.
2. Indic script rendering is untested and no vendor documents it. Test in real Gmail, Apple Mail and Outlook before launch.
3. Resend stores account data and logs in the US regardless of sending region, and none of the three has an India region. Check DPDP obligations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)