### PR TITLE
hotfix: footer domain to vedvyas.com + add radhakrishna.com

### DIFF
--- a/src/components/Footers/Footer.tsx
+++ b/src/components/Footers/Footer.tsx
@@ -168,6 +168,16 @@ const Footer = (props: Props) => {
                   {translate("API")}
                 </a>
               </li>
+              <li>
+                <a
+                  href="https://radhakrishna.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  {translate("Radha Krishna")}
+                </a>
+              </li>
             </ul>
           </div>
 
@@ -219,7 +229,7 @@ const Footer = (props: Props) => {
             <p>
               {`© ${year} ${translate("Copyright")}: `}
               <a
-                href="https://vedvyas.org/"
+                href="https://vedvyas.com/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:underline"


### PR DESCRIPTION
Small footer hotfix, straight off `main`.

## Changes
- **`vedvyas.org` → `vedvyas.com`** on the copyright attribution line. The Foundation's domain moved. The old domain 301s to the new one, so nothing was broken, but there is no reason to ship a permanent redirect on every page's footer, and `.com` is the canonical to hand crawlers.
- **Added `radhakrishna.com`** ("Radha Krishna") to the Resources column, next to the existing external links.

## Verified
- `vedvyas.com` returns 200; `vedvyas.org` 301s to it
- `radhakrishna.com` serves the Foundation's Radha Krishna site (title confirmed)
- Production build renders both links; no `vedvyas.org` reference left anywhere in `src`
- Build clean, eslint clean (one pre-existing repo-wide `font-*` classname warning)

Only `src/` reference to the old domain was this footer line. The `notes/` mentions are planning docs, not the live site, and were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)