### PR TITLE
fix: comparison page body copy failed WCAG AA

### DIFF
--- a/src/app/best-bhagavad-gita-apps/[[...locale]]/page.tsx
+++ b/src/app/best-bhagavad-gita-apps/[[...locale]]/page.tsx
@@ -86,7 +86,7 @@ export default async function Page({
             Equal padding on both sides left a visible hole under the standfirst. */}
         <header className="relative overflow-hidden pt-16 pb-2 md:pt-24 md:pb-4">
           <div className="from-prakash-primary/20 dark:from-nisha-primary/20 absolute inset-0 -z-10 bg-linear-to-b to-transparent" />
-          <div className="container mx-auto max-w-3xl px-4">
+          <div className="container mx-auto max-w-[44rem] px-4">
             {verifiedLabel ? (
               <p className="bg-prakash-primary/10 text-prakash-primary dark:bg-nisha-primary/10 dark:text-nisha-primary mb-6 inline-flex rounded-full px-4 py-1.5 text-sm font-semibold tracking-wide uppercase">
                 Every figure checked {verifiedLabel}
@@ -96,7 +96,7 @@ export default async function Page({
               {doc.heading ?? doc.title}
             </h1>
             {doc.standfirst ? (
-              <p className="text-muted-foreground text-lg leading-relaxed">
+              <p className="text-foreground/85 text-lg leading-relaxed">
                 {doc.standfirst}
               </p>
             ) : null}
@@ -106,7 +106,7 @@ export default async function Page({
         {/* One reading column for the whole page. The blocks that need to be
             wider, the table in particular, scroll inside themselves rather than
             breaking out of it. */}
-        <div className="container mx-auto max-w-3xl px-4 pb-20">
+        <div className="container mx-auto max-w-[44rem] px-4 pb-20">
           <MDXBody doc={doc} />
         </div>
       </article>

--- a/src/components/content/blocks.tsx
+++ b/src/components/content/blocks.tsx
@@ -191,7 +191,7 @@ export function CategoryWinners({ doc }: { doc: ContentDoc }) {
                 {c.winner}
                 <OursTag ours={c.ours} />
               </p>
-              <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              <p className="text-foreground/75 mt-1 text-sm leading-relaxed">
                 {c.why}
               </p>
             </dd>
@@ -272,7 +272,7 @@ export function ComparisonTable({ doc }: { doc: ContentDoc }) {
                   </span>
                 </th>
                 {cols.map(([label, get]) => (
-                  <td key={label} className="text-muted-foreground px-4 py-3">
+                  <td key={label} className="text-foreground/75 px-4 py-3">
                     {get(a)}
                   </td>
                 ))}
@@ -281,7 +281,7 @@ export function ComparisonTable({ doc }: { doc: ContentDoc }) {
           </tbody>
         </table>
       </div>
-      <p className="text-muted-foreground mt-3 text-sm">
+      <p className="text-foreground/70 mt-3 text-sm">
         Ratings from {doc.storefront}, read from the stores&rsquo; own
         structured data. Play shows one decimal; these are its underlying value
         to two.
@@ -319,7 +319,7 @@ export function RankedApps({ doc }: { doc: ContentDoc }) {
                   {a.name}
                   <OursTag ours={a.ours} />
                 </h3>
-                <p className="text-muted-foreground mt-0.5 text-sm">
+                <p className="text-foreground/70 mt-0.5 text-sm">
                   By {a.developer}
                   {a.installs ? ` · ${a.installs} installs` : ""}
                 </p>
@@ -351,7 +351,7 @@ export function RankedApps({ doc }: { doc: ContentDoc }) {
               ).map(([k, v]) => (
                 <div key={k} className="flex gap-2">
                   <dt className="shrink-0 font-semibold">{k}:</dt>
-                  <dd className="text-muted-foreground">{v}</dd>
+                  <dd className="text-foreground/75">{v}</dd>
                 </div>
               ))}
             </dl>
@@ -413,7 +413,7 @@ export function AlsoConsidered({ doc }: { doc: ContentDoc }) {
                 by {a.developer}
               </span>
             </p>
-            <p className="text-muted-foreground mt-1.5 text-sm leading-relaxed">
+            <p className="text-foreground/75 mt-1.5 text-sm leading-relaxed">
               {a.note}
             </p>
           </div>
@@ -440,7 +440,7 @@ export function FaqBlock({ doc }: { doc: ContentDoc }) {
         {doc.faq.map((f) => (
           <div key={f.question} className="p-5 md:p-6">
             <h3 className="font-crimson text-lg font-bold">{f.question}</h3>
-            <p className="text-muted-foreground mt-2 leading-relaxed">
+            <p className="text-foreground/85 mt-2 leading-relaxed">
               {f.answer}
             </p>
           </div>
@@ -462,7 +462,7 @@ export function Provenance({ doc }: { doc: ContentDoc }) {
     timeZone: "UTC",
   });
   return (
-    <section className="border-border text-muted-foreground my-14 border-t pt-8 text-sm leading-relaxed">
+    <section className="border-border text-foreground/75 my-14 border-t pt-8 text-sm leading-relaxed">
       <p>
         Every rating, review count and install figure on this page was read from
         Google Play&rsquo;s and Apple&rsquo;s own structured data on{" "}

--- a/src/components/content/mdx.tsx
+++ b/src/components/content/mdx.tsx
@@ -43,8 +43,23 @@ function componentsFor(doc: ContentDoc) {
         {...props}
       />
     ),
+    // Body copy is foreground, not muted. Setting every paragraph to
+    // `text-muted-foreground` put the page's running text at rgb(131,130,125)
+    // on the cream ground — 3.65:1, under the 4.5:1 WCAG AA needs for body
+    // text. Muted is for captions and asides, not for the thing people came to
+    // read. 18px/32px matches the reading measurements in
+    // docs/ui-reference-analysis.md.
     p: (props: HTMLAttributes<HTMLParagraphElement>) => (
-      <p className="text-muted-foreground my-4 leading-relaxed" {...props} />
+      <p
+        className="text-foreground/90 my-5 text-[1.0625rem] leading-[1.75] md:text-[1.125rem]"
+        {...props}
+      />
+    ),
+    ul: (props: HTMLAttributes<HTMLUListElement>) => (
+      <ul
+        className="text-foreground/90 my-5 list-disc space-y-2 pl-5 text-[1.0625rem] leading-[1.75] md:text-[1.125rem]"
+        {...props}
+      />
     ),
     strong: (props: HTMLAttributes<HTMLElement>) => (
       <strong className="text-foreground font-semibold" {...props} />


### PR DESCRIPTION
I introduced this yesterday in #330 by setting every MDX paragraph to `text-muted-foreground`.

That token is `rgb(131,130,125)` on the cream background — **3.65:1, against the 4.5:1 WCAG AA requires for body text**. It applied to the page's running text, the FAQ answers, the table cells, the per-app fields and the provenance note. Measured, not guessed.

Muted now stays on furniture — labels, eyebrows, developer names. Everything that is content a reader is meant to read moved to foreground with an alpha. Every text block on the page now measures between 8.3:1 and 16.7:1.

Two further measurements, taken against radhakrishna.com's story pages:

| | radhakrishna story | ours before | ours now |
| --- | --- | --- | --- |
| body size / leading | 18px / 32px | 16px / 26px | 17–18px / 1.75 |
| characters per line | 78 | 92 | 75 |
| body contrast | ~10:1 | 3.65:1 | 14.5:1 |

The reading column narrows from 48rem to 44rem to get the measure down.

**Noted, not fixed here:** `--muted-foreground` is 3.65:1 *everywhere it appears on the site*, not just on this page. That is a token-level change with a site-wide blast radius and belongs in the visual pass, not smuggled into a bug fix.