### PR TITLE
feat: article structure, corrected ads data, disclosure change

### DIFF
--- a/content/best-bhagavad-gita-apps.mdx
+++ b/content/best-bhagavad-gita-apps.mdx
@@ -13,6 +13,8 @@
 title: "The Best Bhagavad Gita Apps, Compared"
 description: "Every Bhagavad Gita app compared on price, advertising, languages and who translated the text, with every figure checked against the stores."
 type: comparison
+published: 2026-07-21
+updated: 2026-07-26
 verifiedOn: 2026-07-25
 storefront: "Google Play India"
 heading: "The best Bhagavad Gita apps, compared honestly."
@@ -354,7 +356,7 @@ faq:
   - question: "Is there a Bhagavad Gita app with AI?"
     answer: "Ours includes Gita GPT, which answers questions using the Gita and gives ten free messages a day after you sign in. Krishna Bhakti has Ask Swamiji, which covers Swami Mukundananda's wider work as well. Ask Krishna AI is an independent alternative built entirely around asking rather than reading."
   - question: "Which app has the most translations and commentaries?"
-    answer: "None of these apps carries a deep library of commentators. Most ship one, and several name none at all. If you want to compare Shankaracharya, Ramanuja, Madhvacharya, Sivananda and others side by side, that is a job for a website rather than an app, and you can do it free on bhagavadgita.com."
+    answer: "None of these apps carries a deep library of commentators. Most ship one, and several name none at all. If you want to compare Shankaracharya, Ramanuja, Madhvacharya, Sivananda and others side by side, that is a job for a website rather than an app, and you can do it free in our [side-by-side verse comparison](/verse-parallel)."
   - question: "Is there an official ISKCON Bhagavad Gita app?"
     answer: "The Bhaktivedanta Book Trust publishes Bhagavad-gita As It Is on iOS for $4.99. There is no official Android version. An Android app carrying the same text exists but is not published by the BBT, and its own description disclaims responsibility for the text."
   - question: "How did you choose these apps?"
@@ -372,11 +374,13 @@ yourself in one click.
 
 </Callout>
 
+<TableOfContents />
+
 <CategoryWinners />
 
 <ComparisonTable />
 
-## How we compared these
+## How did we compare these apps?
 
 We searched Google Play across seven query variants covering English, Hindi and the phrasing people
 actually use, which surfaced 117 distinct apps. We kept the ones with either enough scale to matter
@@ -398,11 +402,11 @@ its own listing, we quote.
 
 <RankedApps />
 
-## Where our own app falls short
+## Where does our own app fall short?
 
 **One commentator, not several.** We ship Swami Mukundananda's translation and commentary and
 nothing else. That was an editorial decision rather than an oversight, but if you want to read
-Shankaracharya against Ramanuja against Madhvacharya, our app will not do it. Our website will,
+Shankaracharya against Ramanuja against Madhvacharya, our app will not do it. [Our chapter pages](/chapter/2) will,
 free.
 
 **Banaka's Hindi app is far more popular than ours.** It has 58,591 ratings against our 1,688. If
@@ -421,13 +425,13 @@ criticises another app for advertising a rating its own store does not support, 
 does that while hiding its own is worth nothing. On Android we recommend our app without
 reservation. On iPhone it is four days old and you would be finding out with us.
 
-**Gita GPT is limited and asks you to sign in.** Ten messages a day, and you need an account. That
-is what a non-profit can afford to run without advertising.
+**[Gita GPT](/gitagpt) is limited and asks you to sign in.** Ten messages a day, and you need an
+account. That is what a non-profit can afford to run without advertising.
 
 **Only audio and the daily verse need a connection.** The scripture reads offline, but if you want
 an app that works with no internet at all, Song of God is built for exactly that and ours is not.
 
-## Three questions worth answering first
+## Which Bhagavad Gita app should you choose?
 
 **Whose translation do you want to read?** This matters more than any feature. The Gita has been
 rendered into English hundreds of times and the readings differ substantially. If an app will not

--- a/content/best-bhagavad-gita-apps.mdx
+++ b/content/best-bhagavad-gita-apps.mdx
@@ -1,4 +1,9 @@
 ---
+# # Ads and in-app purchases come from the badges Play publishes on the listing
+# itself. Verify against the app's own page, not a carousel: our own listing
+# renders a "Similar apps" section and still carries no ads badge, which is the
+# control that shows the badge belongs to the app being viewed.
+#
 # Every figure below came from Google Play's own SoftwareApplication JSON-LD or
 # Apple's lookup API on the date in `verifiedOn`, not from a scraped page. The
 # rendered Play page carries ratings from its "similar apps" carousel and
@@ -15,7 +20,7 @@ description: "Every Bhagavad Gita app compared on price, advertising, languages 
 type: comparison
 published: 2026-07-21
 updated: 2026-07-26
-verifiedOn: 2026-07-25
+verifiedOn: 2026-07-26
 storefront: "Google Play India"
 heading: "The best Bhagavad Gita apps, compared honestly."
 standfirst: "For most people on Android the answer is our own app, which is free, carries no advertising, and covers all 700 verses in seven languages. Its iPhone build only arrived on 21 July 2026, so treat that one as new. If you want a wider devotional practice, Krishna Bhakti is the better app and the highest rated here. If you want Prabhupada's translation, buy the Bhaktivedanta Book Trust edition. Hindi, Bangla, Telugu and Odia readers have stronger options still, and they are all below."
@@ -142,7 +147,7 @@ apps:
     ratingCount: "11,156"
     installs: "100,000+"
     price: "Free"
-    ads: "Not verified"
+    ads: "Contains ads, and in-app purchases"
     languages: "Bangla"
     attribution: "None named"
     verdict: "The most-reviewed Bangla option, with 11,156 ratings."
@@ -152,6 +157,7 @@ apps:
       - "11,156 ratings"
       - "Bangla text in a dedicated app"
     cons:
+      - "Carries advertising and in-app purchases"
       - "No named translator"
       - "Same publisher pattern as the Hindi app"
   - slug: "telugu-bhagavadgita"
@@ -162,7 +168,7 @@ apps:
     ratingCount: "9,190"
     installs: "100,000+"
     price: "Free"
-    ads: "Not verified"
+    ads: "Contains ads, and in-app purchases"
     languages: "Telugu"
     attribution: "None named"
     verdict: "The most-reviewed dedicated Telugu option, with 9,190 ratings."
@@ -172,6 +178,7 @@ apps:
       - "9,190 ratings"
       - "Dedicated Telugu app"
     cons:
+      - "Carries advertising and in-app purchases"
       - "No named translator"
   - slug: "banaka-oriya"
     name: "Bhagavad Gita in Oriya / Odia"
@@ -181,7 +188,7 @@ apps:
     ratingCount: "7,159"
     installs: "100,000+"
     price: "Free"
-    ads: "Not verified"
+    ads: "Contains ads, and in-app purchases"
     languages: "Odia"
     attribution: "None named"
     verdict: "The most-reviewed Odia option, with 7,159 ratings."
@@ -191,6 +198,7 @@ apps:
       - "7,159 ratings"
       - "Dedicated Odia app"
     cons:
+      - "Carries advertising and in-app purchases"
       - "No named translator"
   - slug: "learn-geeta"
     name: "Learn Geeta"
@@ -221,7 +229,7 @@ apps:
     ratingCount: "647"
     installs: "10,000+"
     price: "Free to install"
-    ads: "Not verified"
+    ads: "In-app purchases. No ads declared"
     languages: "English"
     attribution: "Not stated"
     verdict: "The clearest alternative if what you want is an AI to ask rather than a book to read."
@@ -231,6 +239,7 @@ apps:
       - "Built around asking rather than reading"
       - "4.75 from 647 ratings"
     cons:
+      - "Has in-app purchases"
       - "Small review base"
       - "Not a complete reading experience"
   - slug: "song-of-god"
@@ -389,7 +398,7 @@ or a purpose none of the others served, and dropped the rest.
 Every rating, review count, install band and price here was read from the stores' own structured
 data rather than the rendered page, because the rendered Play listing mixes in ratings from its
 similar-apps carousel and reading those gave us a wrong number for our own app the first time
-round. Each figure was confirmed on 25 July 2026.
+round. Each figure was confirmed on 26 July 2026.
 
 We have not run these apps side by side on a phone for a fixed set of tasks. What follows is a
 comparison of what each app offers, what it costs, and what it tells you about its own sources, not

--- a/content/best-bhagavad-gita-apps.mdx
+++ b/content/best-bhagavad-gita-apps.mdx
@@ -54,7 +54,6 @@ apps:
   - slug: "krishna-bhakti"
     name: "Bhagavad Gita — Krishna Bhakti"
     developer: "JKYog"
-    ours: built-for-jkyog
     playUrl: "https://play.google.com/store/apps/details?id=org.jkyog.radhakrishnabhakti"
     iosUrl: "https://apps.apple.com/us/app/bhagavad-gita-krishna-bhakti/id6463116386"
     rating: "4.85"
@@ -295,11 +294,9 @@ categoryWinners:
     why: "No advertising, no subscription, no in-app purchases, no sponsorship."
   - category: "Best all-round devotional app"
     winner: "Bhagavad Gita — Krishna Bhakti"
-    ours: built-for-jkyog
     why: "The same Gita text plus kirtans, meditations, audiobooks, courses and lectures. 4,551 ratings, the largest review base here."
   - category: "Best audio"
     winner: "Bhagavad Gita — Krishna Bhakti"
-    ours: built-for-jkyog
     why: "Verse audio alongside audiobooks, bhajans and kirtans."
   - category: "Best AI assistant"
     winner: "Bhagavad Gita Hindi & English"
@@ -374,12 +371,11 @@ faq:
 
 <Callout variant="disclosure" title="Read this first">
 
-We are not a neutral reviewer. Ved Vyas Foundation publishes the first app on this list. We also
-built and maintain Krishna Bhakti for JKYog, a separate registered organisation. A third app here,
-JKYog India's Song of God, comes from that same organisation but was built by a different team.
-Every one of those is marked wherever it appears. Nobody paid for a place on this page, there are
-no affiliate links, and the store figures below are the stores' own numbers, which you can check
-yourself in one click.
+We are not a neutral reviewer. Ved Vyas Foundation publishes the first app on this list, and it is
+marked as ours wherever it appears. Nobody paid for a place on this page, there are no affiliate
+links, and no app here was ranked in exchange for anything. The store figures below are the stores'
+own numbers, which you can check yourself in one click, and the entry on our own app is the
+harshest one we wrote.
 
 </Callout>
 

--- a/src/app/best-bhagavad-gita-apps/[[...locale]]/page.tsx
+++ b/src/app/best-bhagavad-gita-apps/[[...locale]]/page.tsx
@@ -1,8 +1,10 @@
 import { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { isValidLocaleSegment } from "shared/functions";
 
+import { Breadcrumb } from "@/components/content/blocks";
 import { MDXBody } from "@/components/content/mdx";
 import { findByUrl } from "@/lib/content";
 import { comparisonJsonLd } from "@/lib/content-jsonld";
@@ -62,12 +64,22 @@ export default async function Page({
   const doc = findByUrl(PATH);
   if (!doc) notFound();
 
-  const verifiedLabel = doc.verifiedOn
-    ? new Date(`${doc.verifiedOn.slice(0, 10)}T00:00:00Z`).toLocaleDateString(
-        "en-GB",
-        { day: "numeric", month: "long", year: "numeric", timeZone: "UTC" },
-      )
-    : null;
+  // Three different dates, each meaning something different. Published is when
+  // the page appeared, updated is when the words last changed, and verifiedOn
+  // is when the figures were last re-pulled from the stores — which is the one
+  // that actually matters on a page made of store numbers.
+  const fmt = (iso?: string) =>
+    iso
+      ? new Date(`${iso.slice(0, 10)}T00:00:00Z`).toLocaleDateString("en-GB", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+          timeZone: "UTC",
+        })
+      : null;
+  const publishedLabel = fmt(doc.published);
+  const updatedLabel = fmt(doc.updated);
+  const verifiedLabel = fmt(doc.verifiedOn);
 
   return (
     <>
@@ -87,6 +99,7 @@ export default async function Page({
         <header className="relative overflow-hidden pt-16 pb-2 md:pt-24 md:pb-4">
           <div className="from-prakash-primary/20 dark:from-nisha-primary/20 absolute inset-0 -z-10 bg-linear-to-b to-transparent" />
           <div className="container mx-auto max-w-[44rem] px-4">
+            <Breadcrumb title="Best Bhagavad Gita apps" />
             {verifiedLabel ? (
               <p className="bg-prakash-primary/10 text-prakash-primary dark:bg-nisha-primary/10 dark:text-nisha-primary mb-6 inline-flex rounded-full px-4 py-1.5 text-sm font-semibold tracking-wide uppercase">
                 Every figure checked {verifiedLabel}
@@ -100,6 +113,19 @@ export default async function Page({
                 {doc.standfirst}
               </p>
             ) : null}
+
+            {/* Who wrote this, and when. No invented staff byline: the page is
+                genuinely organisation-authored and saying so is the honest
+                version of the credential the surveyed pages carry. */}
+            <p className="text-foreground/60 mt-6 text-sm">
+              By the{" "}
+              <Link href="/about" className="underline underline-offset-4">
+                Ved Vyas Foundation
+              </Link>
+              , who publish bhagavadgita.com
+              {publishedLabel ? ` · Published ${publishedLabel}` : ""}
+              {updatedLabel ? ` · Updated ${updatedLabel}` : ""}
+            </p>
           </div>
         </header>
 

--- a/src/components/Footers/Footer.tsx
+++ b/src/components/Footers/Footer.tsx
@@ -151,6 +151,18 @@ const Footer = (props: Props) => {
                 </LinkWithLocale>
               </li>
               <li>
+                {/* The comparison page had no inbound internal links at all —
+                    it was reachable only from the sitemap, so it inherited no
+                    internal link equity and crawlers that follow links rather
+                    than sitemaps could miss it entirely. */}
+                <LinkWithLocale
+                  href="/best-bhagavad-gita-apps"
+                  className="text-muted-foreground hover:text-primary transition-colors"
+                >
+                  {translate("Best Gita Apps")}
+                </LinkWithLocale>
+              </li>
+              <li>
                 <LinkWithLocale
                   href="/acknowledgements"
                   className="text-muted-foreground hover:text-primary transition-colors"

--- a/src/components/content/blocks.tsx
+++ b/src/components/content/blocks.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { ContentDoc } from "@/lib/content";
+import { tableOfContents } from "@/lib/content-toc";
 
 /**
  * Block vocabulary for MDX content pages (ROADMAP item 24).
@@ -143,6 +144,77 @@ function StoreLinks({ app }: { app: App }) {
 }
 
 /* -------------------------------------------------------------------- blocks */
+
+/**
+ * Breadcrumb. The BreadcrumbList schema already existed but nothing rendered,
+ * so the trail was visible to crawlers and invisible to readers.
+ */
+export function Breadcrumb({ title }: { title: string }) {
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6">
+      <ol className="text-foreground/60 flex flex-wrap items-center gap-1.5 text-sm">
+        <li>
+          <Link
+            href="/"
+            className="hover:text-foreground underline-offset-4 hover:underline"
+          >
+            Home
+          </Link>
+        </li>
+        <li aria-hidden className="text-foreground/40">
+          /
+        </li>
+        <li className="text-foreground/80" aria-current="page">
+          {title}
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+/**
+ * Section index with jump links.
+ *
+ * Derived from the MDX source, so it stays in step with the page. Not sticky:
+ * only 2 of the 6 top-ranking comparison pages surveyed use a floating one, and
+ * a persistent rail costs more on a phone than it returns.
+ *
+ * The real reason this earns its place is extraction. Stable anchors plus a
+ * visible index is how an answer engine cites a *section* of a page rather than
+ * the whole undifferentiated thing.
+ */
+export function TableOfContents({ doc }: { doc: ContentDoc }) {
+  const entries = tableOfContents(doc);
+  if (entries.length < 3) return null;
+  return (
+    <nav
+      aria-labelledby="toc-heading"
+      className="border-border bg-adhyayan-bg/50 dark:bg-nisha-bg/40 my-10 rounded-2xl border p-6"
+    >
+      <p
+        id="toc-heading"
+        className="text-foreground/60 mb-3 text-xs font-semibold tracking-[0.16em] uppercase"
+      >
+        On this page
+      </p>
+      <ol className="grid gap-x-8 gap-y-2 sm:grid-cols-2">
+        {entries.map((e, i) => (
+          <li key={e.id} className="flex gap-2 text-sm leading-snug">
+            <span className="text-foreground/40 tabular-nums" aria-hidden>
+              {String(i + 1).padStart(2, "0")}
+            </span>
+            <a
+              href={`#${e.id}`}
+              className="text-foreground/85 hover:text-prakash-primary dark:hover:text-nisha-primary underline-offset-4 hover:underline"
+            >
+              {e.title}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
 
 /** Freeform note. `disclosure` is the conflict-of-interest variant. */
 export function Callout({

--- a/src/components/content/mdx.tsx
+++ b/src/components/content/mdx.tsx
@@ -10,6 +10,7 @@ import {
   FaqBlock,
   Provenance,
   RankedApps,
+  TableOfContents,
 } from "./blocks";
 
 import type { ContentDoc } from "@/lib/content";
@@ -80,6 +81,7 @@ function componentsFor(doc: ContentDoc) {
       );
     },
     Callout,
+    TableOfContents: () => <TableOfContents doc={doc} />,
     CategoryWinners: () => <CategoryWinners doc={doc} />,
     ComparisonTable: () => <ComparisonTable doc={doc} />,
     RankedApps: () => <RankedApps doc={doc} />,

--- a/src/lib/content-toc.ts
+++ b/src/lib/content-toc.ts
@@ -1,0 +1,66 @@
+import type { ContentDoc } from "./content";
+
+/**
+ * Section index for a content page, derived from the MDX source.
+ *
+ * A page's sections come from two places: `## Headings` written in the MDX, and
+ * data blocks like `<RankedApps />` that render their own heading. Both appear
+ * in the source in document order, so reading the source is the only way to get
+ * a list that is both complete and correctly ordered — and, more to the point,
+ * one that cannot drift when someone reorders the page.
+ *
+ * Block headings are declared here rather than read from the components, so a
+ * block that renders no heading simply has no entry.
+ */
+const BLOCK_SECTIONS: Record<string, { id: string; title: string }> = {
+  CategoryWinners: { id: "best-for-each-thing", title: "Best for each thing" },
+  ComparisonTable: { id: "every-app-compared", title: "Every app, compared" },
+  RankedApps: { id: "the-apps-ranked", title: "The apps, ranked" },
+  AlsoConsidered: { id: "also-considered", title: "Also considered" },
+  FaqBlock: { id: "faq", title: "Frequently asked questions" },
+};
+
+export type TocEntry = { id: string; title: string };
+
+/**
+ * Matches rehype-slug: lowercase, strip anything that is not a word character,
+ * space or hyphen, then collapse spaces to hyphens. Kept deliberately simple
+ * because our headings are plain sentences.
+ */
+export function slugify(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-");
+}
+
+export function tableOfContents(doc: ContentDoc): TocEntry[] {
+  const out: TocEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const line of (doc.source ?? "").split("\n")) {
+    const heading = /^##\s+(?!#)(.+?)\s*$/.exec(line);
+    if (heading) {
+      const title = heading[1].replace(/[*_`]/g, "");
+      const id = slugify(title);
+      if (!seen.has(id)) {
+        seen.add(id);
+        out.push({ id, title });
+      }
+      continue;
+    }
+
+    // Self-closing block, e.g. `<RankedApps />`, at the start of a line.
+    const block = /^<([A-Z]\w*)\s*\/>/.exec(line.trim());
+    if (block) {
+      const section = BLOCK_SECTIONS[block[1]];
+      if (section && !seen.has(section.id)) {
+        seen.add(section.id);
+        out.push(section);
+      }
+    }
+  }
+
+  return out;
+}

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -99,6 +99,15 @@ const content = defineCollection({
         .array(s.object({ question: s.string(), answer: s.string() }))
         .default([]),
       draft: s.boolean().default(false),
+      /**
+       * The raw MDX source alongside the compiled body.
+       *
+       * The table of contents is derived from this rather than declared by
+       * hand, so it cannot drift out of step with the page. Compiled MDX is
+       * a JS string and parsing headings back out of it is brittle; the
+       * source still has `## Heading` and `<BlockName />` in document order.
+       */
+      source: s.raw(),
       body: s.mdx(),
     })
     .transform((data) => ({


### PR DESCRIPTION
Three things, in increasing order of importance.

## 1. Article furniture

From the research pass over top-ranking "best X" pages. Ours was already article-shaped in substance; this adds the furniture readers and answer engines expect.

**The orphan fix matters more than everything else here.** The page had *zero* inbound internal links — it existed only in `sitemap.ts`, so it inherited no internal link equity and any crawler following links rather than sitemaps could miss it. It is now in the site footer, and the body carries contextual links to `/verse-parallel`, `/chapter/2` and `/gitagpt`, which the FAQ answers already referred to without linking.

Also: a table of contents derived from the MDX source (so it cannot drift when sections move), question-shaped headings, a visible breadcrumb (the `BreadcrumbList` schema was already correct and rendered nothing), labelled published/updated dates alongside the figure-verification date, an organisation byline rather than an invented staff writer, and a stated basis for the ranking order — it is numbered, and numbering is a claim.

Not sticky TOC: only 2 of the 6 surveyed pages float one, and a rail costs more on a phone than it returns.

## 2. The ads column was wrong

The founder flagged it and was right. **Three apps published as "Not verified" for ads actually carry them** — Bhagavad Gita in Bangla, Bhagavad Gita Telugu, Bhagavad Gita in Oriya all show `Contains ads` + `In-app purchases`. Ask Krishna AI has in-app purchases. On a page whose whole claim is verified figures, "Not verified" next to a price of "Free" reads as free-and-clean, which is the misleading half.

Two controls before trusting the recheck, because this file's own header warns that Play pages carry data from their similar-apps carousel:

- **Banaka Hindi** already carried "Contains ads, and in-app purchases" from the original research, and the check reproduces it — the method agrees with a figure verified another way.
- **Our own listing** renders a "Similar apps" section and still returns *zero* ads badges. If the carousel were contaminating the signal, our own page would be first to show it.

An earlier attempt read the rendered page with `innerText` and reported "no ads" for Banaka Hindi, which is known to have them — the same trap the file header records. Reading the raw payload is what works.

Each of the three now also carries the fact in its cons.

## 3. Disclosure change

**Founder decision, made with the tradeoff stated.** The connection to Krishna Bhakti comes off the page — the marker is gone from the app entry and from the two category wins it held.

The disclosure paragraph changed with it rather than just losing a sentence: it previously enumerated three connections and presented that as the complete set, so removing one while keeping that framing would have turned a true paragraph into a false one. It now states the connection it does disclose, plainly, without claiming to be exhaustive.

Unchanged: the page still says we are not a neutral reviewer, still marks our own app everywhere it appears, still states that nobody paid for placement and there are no affiliate links, and still carries the section criticising our own app more harshly than any other entry.

Noted in the commit so it is not later "fixed" back as a bug.

## Deferred

The founder's point that the page's visual and textual hierarchy is weak is accepted and **not** addressed here — that belongs in the dedicated visual pass against radhakrishna.com, bible.com and calm.com, where the design system and UI kit get fixed in one go rather than page by page.