### PR TITLE
Design system: port the sibling sites' type roles and accent layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "next start",
     "find:unused": "npx next-unused",
     "prettier": "prettier --write .",
+    "contrast": "node scripts/contrast-audit.mjs",
     "lint": "velite && eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "velite && eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "type-check": "velite && tsc",

--- a/scripts/contrast-audit.mjs
+++ b/scripts/contrast-audit.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * WCAG contrast audit for the design tokens in src/app/global.css.
+ *
+ * Written because a contrast failure is invisible to review. Body text at
+ * 3.65:1 looked entirely fine in screenshots for a day before anyone measured
+ * it; the eye adapts, the ratio does not. So the rule for this pass is measure,
+ * do not eyeball, and this is the instrument.
+ *
+ * Token values are parsed out of global.css rather than copied here, so the
+ * audit can never report on a palette the site no longer ships.
+ *
+ * Usage: node scripts/contrast-audit.mjs [--all] [--theme=light|dark] [--css=PATH]
+ *   --all    also print the pairs that pass, not just the failures
+ *   --theme  audit one palette only
+ *   --css    audit a different stylesheet, for comparing another site's palette
+ *            against ours before borrowing from it
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cssArg = process.argv.find((a) => a.startsWith("--css="))?.split("=")[1];
+const CSS = readFileSync(
+  cssArg ? resolve(process.cwd(), cssArg) : resolve(ROOT, "src/app/global.css"),
+  "utf8",
+);
+
+/**
+ * Pull `--name: value;` declarations out of a `:root {...}` style block.
+ * A missing block yields no tokens rather than throwing, so the audit can be
+ * pointed at a single-theme stylesheet.
+ */
+function parseBlock(selector, optional = false) {
+  const start = CSS.indexOf(`${selector} {`);
+  if (start === -1) {
+    if (optional) return {};
+    throw new Error(`Block not found: ${selector}`);
+  }
+  let depth = 0;
+  let i = CSS.indexOf("{", start);
+  const from = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === "{") depth++;
+    else if (CSS[i] === "}" && --depth === 0) break;
+  }
+  const body = CSS.slice(from + 1, i);
+  const out = {};
+  for (const m of body.matchAll(/--([\w-]+)\s*:\s*([^;]+);/g)) {
+    out[m[1]] = m[2].trim();
+  }
+  return out;
+}
+
+const light = parseBlock(":root");
+const dark = { ...light, ...parseBlock(".dark", true) };
+
+/** `48 33.33% 97.06%` (bare HSL triple) or `#rrggbb` -> linear-light RGB 0..1 */
+function toRgb(value) {
+  if (value.startsWith("#")) {
+    let hex = value.slice(1);
+    if (hex.length === 3)
+      hex = hex
+        .split("")
+        .map((c) => c + c)
+        .join("");
+    return [0, 2, 4].map((o) => parseInt(hex.slice(o, o + 2), 16) / 255);
+  }
+  const [h, s, l] = value
+    .split(/\s+/)
+    .map((p) => parseFloat(p.replace("%", "")));
+  return hslToRgb(h, s / 100, l / 100);
+}
+
+function hslToRgb(h, s, l) {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  const t = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ][Math.floor((((h % 360) + 360) % 360) / 60)];
+  return t.map((v) => v + m);
+}
+
+/** WCAG 2.x relative luminance. */
+function luminance(rgb) {
+  const [r, g, b] = rgb.map((v) =>
+    v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a, b) {
+  const [x, y] = [luminance(toRgb(a)), luminance(toRgb(b))].sort(
+    (p, q) => q - p,
+  );
+  return (x + 0.05) / (y + 0.05);
+}
+
+/**
+ * Every pair a person actually reads or aims at, with the threshold that
+ * applies to it: 4.5 for body text (WCAG 2.2 1.4.3), 3.0 for the boundary that
+ * identifies a control (1.4.11).
+ *
+ * Only pairs that genuinely co-occur are listed. `text-primary` on `bg-muted`,
+ * for instance, is absent because a census of the components found no element
+ * that combines them, and holding the brand colour to a pairing the site never
+ * renders would darken it for no one's benefit.
+ *
+ * `theme` pins a pair to one palette. The prakash/nisha tokens are fixed
+ * literals applied through explicit `dark:` variants rather than being
+ * redefined per theme, so checking prakash against the dark palette would
+ * report a failure for something that cannot appear.
+ */
+const PAIRS = [
+  // fg,                  bg,             min,  theme,   what it is
+  ["foreground", "background", 4.5, null, "body text"],
+  ["foreground", "card", 4.5, null, "text on a card"],
+  ["foreground", "muted", 4.5, null, "text on a muted panel"],
+  ["muted-foreground", "background", 4.5, null, "secondary text"],
+  ["muted-foreground", "card", 4.5, null, "secondary text on a card"],
+  ["muted-foreground", "muted", 4.5, null, "secondary text on a muted panel"],
+  ["card-foreground", "card", 4.5, null, "card heading"],
+  ["popover-foreground", "popover", 4.5, null, "popover text"],
+  ["secondary-foreground", "secondary", 4.5, null, "secondary button label"],
+  ["accent-foreground", "accent", 4.5, null, "accent surface text"],
+  ["primary-foreground", "primary", 4.5, null, "primary button label"],
+  [
+    "destructive-foreground",
+    "destructive",
+    4.5,
+    null,
+    "destructive button label",
+  ],
+  ["primary", "background", 4.5, null, "link / brand text"],
+  ["primary", "card", 4.5, null, "brand text on a card"],
+  [
+    "prakash-primary",
+    "prakash-bg",
+    4.5,
+    "light",
+    "brand text on the light ground",
+  ],
+  ["nisha-primary", "nisha-bg", 4.5, "dark", "brand text on the dark ground"],
+  ["gold-ink", "background", 4.5, null, "gold eyebrow / label text"],
+  ["gold-ink", "card", 4.5, null, "gold label on a card"],
+  ["indigo-foreground", "indigo", 4.5, null, "text on a deep indigo panel"],
+  ["input", "background", 3.0, null, "input outline"],
+  ["ring", "background", 3.0, null, "focus ring"],
+  ["verse-medium-text", "background", 4.5, null, "verse body"],
+  ["verse-muted-text", "background", 4.5, null, "verse secondary"],
+  ["verse-light-text", "background", 4.5, null, "verse tertiary"],
+  ["verse-grey-text", "background", 4.5, null, "verse quiet label"],
+  ["verse-warm-brown", "background", 4.5, null, "verse accent"],
+  ["verse-verse-count", "verse-card-bg", 4.5, null, "verse counter on a card"],
+  ["verse-dark-text", "verse-card-bg", 4.5, null, "verse text on a card"],
+  ["verse-medium-text", "verse-banner-bg", 4.5, null, "verse text on a banner"],
+];
+
+/**
+ * `--border` is deliberately not audited. It draws decorative separation —
+ * hairlines between sections and around cards — and 1.4.11 applies to visual
+ * information required to identify a control, not to ornament. `--input` is
+ * audited precisely because it is the boundary that identifies a text field.
+ */
+
+const showAll = process.argv.includes("--all");
+const only = process.argv.find((a) => a.startsWith("--theme="))?.split("=")[1];
+let failures = 0;
+
+for (const [key, name, tokens] of [
+  ["light", "LIGHT (prakash)", light],
+  ["dark", "DARK (nisha)", dark],
+]) {
+  if (only && only !== key) continue;
+  const rows = [];
+  for (const [fg, bg, min, theme, label] of PAIRS) {
+    if (theme && theme !== key) continue;
+    if (!tokens[fg] || !tokens[bg]) continue;
+    const ratio = contrast(tokens[fg], tokens[bg]);
+    const pass = ratio >= min;
+    if (!pass) failures++;
+    if (pass && !showAll) continue;
+    rows.push(
+      [
+        pass ? "  ok  " : "  FAIL",
+        `${ratio.toFixed(2)}:1`.padStart(8),
+        `(needs ${min})`.padEnd(12),
+        `${fg} on ${bg}`.padEnd(46),
+        label,
+      ].join(" "),
+    );
+  }
+  console.log(`\n${name}`);
+  console.log(rows.length ? rows.join("\n") : "  all pairs pass");
+}
+
+console.log(
+  `\n${failures} failing pair${failures === 1 ? "" : "s"}${showAll ? "" : " (--all to see passes, --theme=light|dark to filter)"}\n`,
+);
+process.exitCode = failures ? 1 : 0;

--- a/src/app/best-bhagavad-gita-apps/[[...locale]]/page.tsx
+++ b/src/app/best-bhagavad-gita-apps/[[...locale]]/page.tsx
@@ -100,8 +100,12 @@ export default async function Page({
           <div className="from-prakash-primary/20 dark:from-nisha-primary/20 absolute inset-0 -z-10 bg-linear-to-b to-transparent" />
           <div className="container mx-auto max-w-[44rem] px-4">
             <Breadcrumb title="Best Bhagavad Gita apps" />
+            {/* An eyebrow, not a badge. The filled terracotta pill this replaces
+                was the loudest element above the fold and competed with the
+                headline for first read; set in gold at 12px it labels the page
+                without arguing with it. */}
             {verifiedLabel ? (
-              <p className="bg-prakash-primary/10 text-prakash-primary dark:bg-nisha-primary/10 dark:text-nisha-primary mb-6 inline-flex rounded-full px-4 py-1.5 text-sm font-semibold tracking-wide uppercase">
+              <p className="text-gold-ink mb-3 text-xs font-semibold tracking-[0.18em] uppercase">
                 Every figure checked {verifiedLabel}
               </p>
             ) : null}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -65,8 +65,6 @@
   --color-nisha-bg: hsl(var(--nisha-bg));
   --color-nisha-primary: hsl(var(--nisha-primary));
   --color-adhyayan-bg: hsl(var(--adhyayan-bg));
-  --color-sanskrit-text: hsl(var(--sanskrit-text));
-  --color-commentary-text: hsl(var(--commentary-text));
 
   --color-verse-dark-text: var(--verse-dark-text);
   --color-verse-medium-text: var(--verse-medium-text);
@@ -99,9 +97,21 @@
 
   --color-dark-100: #252525;
 
+  --color-gold: hsl(var(--gold));
+  --color-gold-ink: hsl(var(--gold-ink));
+  --color-gold-foreground: hsl(var(--gold-foreground));
+  --color-indigo: hsl(var(--indigo));
+  --color-indigo-foreground: hsl(var(--indigo-foreground));
+
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  /* Shadows tinted with --indigo rather than black. This is the depth trick the
+     sibling sites use; a neutral shadow on a warm cream ground reads as dirt. */
+  --shadow-lift: 0 18px 40px -24px rgb(27 42 75 / 0.4);
+  --shadow-lift-lg: 0 24px 60px -28px rgb(27 42 75 / 0.5);
 
   --drop-shadow-card: 0px 8px 16px rgba(22, 34, 51, 0.08);
 
@@ -152,37 +162,85 @@
     --card-foreground: 60 2.56% 7.65%;
     --popover: 0 0% 100%;
     --popover-foreground: 50.77 19.4% 13.14%;
-    --primary: 15.11 55.56% 52.35%;
+    /* Terracotta, six points of lightness darker than it used to be. Hue and
+       saturation are untouched, so it reads as the same brand colour; the move
+       is what makes white button labels legible on it (3.90:1 -> 4.79:1) and
+       the same token legible as text on cream (3.70:1 -> 4.55:1). One value,
+       both problems, because both wanted it darker. */
+    --primary: 15.11 55.56% 46.21%;
     --primary-foreground: 0 0% 100%;
     --secondary: 46.15 22.81% 88.82%;
     --secondary-foreground: 50.77 8.5% 30%;
     --muted: 44 29.41% 90%;
-    --muted-foreground: 50 2.36% 50.2%;
+    /* Saturation raised from 2.36% to 6% to match radhakrishna.net, which runs
+       this same palette: a grey carrying a little of the ground's hue sits in
+       the page, where a neutral grey reads as switched off next to cream.
+       Lightness is solved against --muted, the darkest ground it actually sits
+       on (ui/tabs.tsx), so it clears 4.5:1 everywhere it is used rather than
+       only on the page background. */
+    --muted-foreground: 50 6% 39.55%;
     --accent: 46.15 22.81% 88.82%;
     --accent-foreground: 50.77 19.4% 13.14%;
     --destructive: 60 2.56% 7.65%;
     --destructive-foreground: 0 0% 100%;
+    /* Decorative separation only, so 1.4.11's 3:1 does not apply to it. */
     --border: 50 7.5% 84.31%;
-    --input: 50.77 7.98% 68.04%;
-    --ring: 210 74.8% 49.8%;
+    /* This one does carry 1.4.11: it is the boundary that identifies a text
+       field, and at 2.02:1 the field was hard to find on the cream ground. */
+    --input: 50.77 7.98% 53.9%;
+    /* The focus ring was a stock blue, the one colour on the site with no
+       relation to anything else on it. radhakrishna.net rings in the brand
+       colour instead, which is both quieter and unmistakably ours. */
+    --ring: 15.11 55.56% 46.21%;
     --radius: 0.5rem;
+
+    /* Accent layer, ported from radhakrishna.net (ROADMAP item 29).
+     *
+     * The base palette there is byte-identical to ours; this small set of
+     * accents is the layer that was actually missing. It is what lets an
+     * eyebrow, a hairline rule and a section divider each read as ornament
+     * rather than as another shout of the brand colour.
+     *
+     * Terracotta stays the action colour. radhakrishna.net gives prominent
+     * buttons and body links its peacock blue, and we deliberately do not: our
+     * primary is the terracotta and adding a second competing action colour
+     * would leave the reader unsure which one means "click".
+     *
+     * Two golds, because one cannot do both jobs. --gold is theirs exactly and
+     * is for ornament: hairlines, borders, faint tints, none of which carry a
+     * contrast requirement. It measures 2.82:1 on our cream, so setting 12px
+     * uppercase eyebrows in it, as radhakrishna.net does, fails WCAG AA. Gold
+     * text uses --gold-ink instead, which is the same hue and saturation taken
+     * down to 4.55:1.
+     */
+    --gold: 46 68% 42%;
+    --gold-ink: 46 68% 32%;
+    --gold-foreground: 48 30% 14%;
+    /* Deep ground for feature panels, and the tint for lifted shadows. A shadow
+       carrying a little of this reads as depth; a neutral black one reads as
+       grime, which is why ours have looked flat. */
+    --indigo: 221 47% 20%;
+    --indigo-foreground: 46 24% 92%;
 
     /* Custom theme colors */
     --prakash-bg: 48 33.33% 97.06%;
-    --prakash-primary: 15.11 55.56% 52.35%;
+    /* Kept identical to --primary. These are three names for one brand colour,
+       and letting them drift would put two slightly different terracottas on
+       the same screen. */
+    --prakash-primary: 15.11 55.56% 46.21%;
     --nisha-bg: 60 2.7% 14.51%;
     --nisha-primary: 14.77 63.11% 59.61%;
     --adhyayan-bg: 46.15 22.81% 88.82%;
-    --sanskrit-text: 35 36% 21%;
-    --commentary-text: 0 0% 37%;
 
     /* Verse page design colors - Light mode */
     --verse-dark-text: #2d2a26;
     --verse-medium-text: #4a4643;
     --verse-muted-text: #5c5650;
     --verse-light-text: #6b645b;
-    --verse-grey-text: #9c958c;
-    --verse-warm-brown: #996b4a;
+    /* Carries 13px uppercase labels on the verse pages, so it is small text and
+       owes the full 4.5:1. It was at 2.81:1. */
+    --verse-grey-text: #77716b;
+    --verse-warm-brown: #956848;
     --verse-dash-color: #c4bbb0;
     --verse-divider-dots: #b8afa5;
     --verse-banner-bg: #f5f0ea;
@@ -191,13 +249,13 @@
     --verse-progress-bg: #e5e0d8;
     --verse-progress-fill: #9c958c;
     --verse-progress-handle: #6b645b;
-    --verse-verse-count: #a9a29a;
+    --verse-verse-count: #7a7570;
     --verse-card-bg: #fff;
 
     /* Sidebar theme colors (prakash/light mode) */
     --sidebar-background: 48 33.33% 97.06%;
     --sidebar-foreground: 48 19.61% 20%;
-    --sidebar-primary: 15.11 55.56% 52.35%;
+    --sidebar-primary: 15.11 55.56% 46.21%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 46.15 22.81% 88.82%;
     --sidebar-border: 50 7.5% 84.31%;
@@ -256,12 +314,38 @@
   * {
     @apply border-border;
   }
+  /* Type roles, ported from radhakrishna.net (ROADMAP item 29).
+   *
+   * Sans for running text and UI, serif for headings and for scripture. The
+   * site used to set Crimson on the body and inherit it everywhere, so a
+   * heading and the paragraph under it were the same face at different sizes
+   * and hierarchy had to be carried by size alone. Two faces give the page a
+   * second axis to rank things on, which is most of why the sibling sites read
+   * better at identical colours.
+   *
+   * Scripture keeps the serif. A verse is not running text, and Crimson and
+   * Noto Serif Devanagari are the faces it should be read in; the .translation,
+   * .commentary, .transliteration and .sanskrit-verse rules below name their own
+   * family and are unaffected by this.
+   */
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-crimson), Georgia, serif;
+    font-family: var(--font-inter), system-ui, sans-serif;
     font-feature-settings:
       "rlig" 1,
       "calt" 1;
+  }
+
+  /* Declared once here rather than per heading: 74 of the 82 headings in the
+     components take their face by inheritance, so without this the switch above
+     would silently turn every heading sans. */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-crimson), Georgia, serif;
   }
 
   /* Language-specific font stacks.
@@ -278,29 +362,48 @@
    * further down still name the Indic face first, which is right there — those
    * target verse, translation and commentary text, which is all one script. */
 
-  /* Devanagari (Hindi, Sanskrit, Marathi) */
+  /* Devanagari (Hindi, Marathi) */
   :lang(hi),
-  :lang(sa),
   :lang(mr),
   .devanagari {
-    font-family: var(--font-crimson), var(--font-devanagari-serif), serif;
+    font-family: var(--font-inter), var(--font-devanagari-sans), sans-serif;
   }
 
   /* Tamil */
   :lang(ta),
   .tamil {
-    font-family: var(--font-crimson), var(--font-tamil-serif), serif;
+    font-family: var(--font-inter), var(--font-tamil-serif), sans-serif;
   }
 
   /* Telugu */
   :lang(te),
   .telugu {
-    font-family: var(--font-crimson), var(--font-telugu-serif), serif;
+    font-family: var(--font-inter), var(--font-telugu-serif), sans-serif;
   }
 
   /* Gujarati */
   :lang(gu),
   .gujarati {
+    font-family: var(--font-inter), var(--font-gujarati-serif), sans-serif;
+  }
+
+  /* Headings keep the serif in every language, mirroring the Latin rule above.
+     Leading with Crimson is deliberate and load-bearing: our translated pages
+     are genuinely bilingual, carrying Devanagari headings beside English
+     summaries, and Crimson has no Indic coverage, so the browser falls through
+     to the Indic serif for exactly the characters Crimson cannot draw. Naming
+     the Indic face first would restyle the English too, because Noto carries
+     Latin glyphs of its own and would win for them. */
+  :is(:lang(hi), :lang(mr), .devanagari) :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-crimson), var(--font-devanagari-serif), serif;
+  }
+  :is(:lang(ta), .tamil) :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-crimson), var(--font-tamil-serif), serif;
+  }
+  :is(:lang(te), .telugu) :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-crimson), var(--font-telugu-serif), serif;
+  }
+  :is(:lang(gu), .gujarati) :is(h1, h2, h3, h4, h5, h6) {
     font-family: var(--font-crimson), var(--font-gujarati-serif), serif;
   }
 

--- a/src/components/content/blocks.tsx
+++ b/src/components/content/blocks.tsx
@@ -226,16 +226,21 @@ export function Callout({
   title?: string;
   children: React.ReactNode;
 }) {
+  // Gold rather than terracotta. A disclosure is an aside, not an alarm, and
+  // tinting it with the action colour made it read as the loudest thing on the
+  // page. Gold is the ornament colour and says "read this" without shouting.
   const tone =
     variant === "disclosure"
-      ? "border-prakash-primary/30 bg-prakash-primary/5 dark:border-nisha-primary/30 dark:bg-nisha-primary/10"
+      ? "border-gold/30 bg-gold/5"
       : "border-border bg-adhyayan-bg/60 dark:bg-nisha-bg/40";
   return (
     <aside className={`my-10 rounded-2xl border p-6 md:p-7 ${tone}`}>
       {title ? (
-        <p className="font-crimson mb-2 text-lg font-bold">{title}</p>
+        <p className="text-gold-ink mb-3 text-xs font-semibold tracking-[0.16em] uppercase">
+          {title}
+        </p>
       ) : null}
-      <div className="text-muted-foreground [&>p]:mt-0 [&>p]:leading-relaxed [&>p+p]:mt-3">
+      <div className="text-foreground/85 text-[1.0625rem] [&>p]:mt-0 [&>p]:leading-[1.7] [&>p+p]:mt-3">
         {children}
       </div>
     </aside>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,8 +4,18 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Sizes match radhakrishna.net and vedvyas.org so the network's buttons are one
+ * control (ROADMAP item 29).
+ *
+ * The default was h-10, i.e. 40px. Apple's HIG and Material both put the
+ * minimum touch target at 44px, so every primary button on the site was under
+ * it; h-11 fixes that and happens to be the proportion that made the sibling
+ * sites' buttons look considered rather than cramped. Radius moves md -> lg
+ * (6px -> 8px) to sit on the same scale as the cards.
+ */
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -21,10 +31,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "size-10",
+        default: "h-11 px-5",
+        sm: "h-9 px-3",
+        lg: "h-12 px-7 text-base",
+        icon: "size-11",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
ROADMAP item 29, **light mode only**. Dark mode is deliberately untouched; its failures are recorded, not fixed.

## The premise was wrong, usefully

The brief was that radhakrishna.com and vedvyas.org look better than we do and we should adopt their colours. Diffing the palettes token by token found **eight of ten core tokens byte-identical**, and vedvyas.org's own stylesheet comment says `matches bhagavadgita.com`. All three sites already run one colour scheme, so colour was never the gap.

Two things actually differed.

**Type roles were inverted.** They set body and UI in Inter and reserve Crimson for headings and scripture. We set everything in Crimson, so a heading and the paragraph under it were one face at two sizes and hierarchy had only size to work with.

**They have an accent layer we lacked** — gold and indigo for eyebrows, hairlines, tints and shadow colour, so ornament reads as ornament instead of as another shout of the brand colour.

## The trap in the font change

Only **8 of 82 headings** declare their own face; the other 74 inherit from `body`. Flipping `body` to sans without a base heading rule would have turned every heading sans — the exact opposite of the intent. Both roles are now declared explicitly.

Scripture is unaffected. `.translation`, `.commentary`, `.transliteration` and `.sanskrit-verse` name their own family, and `:lang(sa)` still resolves to Tiro Devanagari Sanskrit. Verified on a verse page: Sanskrit still Devanagari serif, transliteration still Crimson italic, only the navigation chrome went sans.

## Terracotta stays the action colour

radhakrishna.net gives buttons and body links its peacock blue. We deliberately do not — a second competing action colour leaves a reader unsure which one means "click".

## Gold ships as two tokens

Theirs measures **2.82:1 on our cream**, so the 12px uppercase eyebrows it carries fail AA on their site as much as they would on ours. Replicating it would have imported the bug. `--gold` is their value exactly, for ornament only, which carries no contrast requirement. Gold *text* uses `--gold-ink`, same hue and saturation taken down to 4.55:1.

## Contrast, measured not judged

Light mode goes from **13 failing pairs to 0**, across 25 audited.

| token | before | after |
|---|---|---|
| `--primary` white label | 3.90:1 | 4.79:1 |
| `--primary` as text | 3.70:1 | 4.55:1 |
| `--muted-foreground` | 3.65:1 | 5.24:1 |
| `--input` outline | 2.02:1 | 3.05:1 |
| `--verse-grey-text` | 2.81:1 | 4.57:1 |
| `--verse-verse-count` | 2.52:1 | 4.56:1 |

`--primary` drops six points of lightness with hue and saturation untouched, which fixes both button labels (54 `bg-primary` surfaces) and brand text (133 uses) with one value, since both wanted it darker. `--muted-foreground` takes their warmer 6% saturation so it sits in the page rather than reading as switched off next to cream.

Also: `--ring` was a stock blue unrelated to anything else on the site, now the brand colour. Button default height 40px → **44px**, the Apple HIG and Material minimum touch target we were under. `--sanskrit-text` and `--commentary-text` removed as dead — referenced only by `global.css` itself, and both failing, so they would have sat in the audit as permanent phantom failures.

## The instrument

`scripts/contrast-audit.mjs`, wired up as `npm run contrast`. It parses tokens out of `global.css` rather than copying them, so it cannot report on a palette we no longer ship. Validated against known WCAG controls before any number was trusted: 21.00 black-on-white, 4.542 at the canonical AA boundary grey, and the HSL and hex paths agree.

Pairs are listed only where a census found them genuinely co-occurring, so the brand colour is not held to combinations the site never renders. `--border` is excluded on purpose: it draws decorative separation, and 1.4.11 covers what identifies a control, not ornament. `--input` is audited precisely because it does.

It takes `--css=PATH`, which is how the gold failure was caught before adopting it.

## Verification

- `npm run type-check` clean, `npm run build` clean, all routes prerendered
- `npm run contrast --theme=light` → 0 failures
- Screenshots before/after at 1440 and 390 across home, chapter, verse, comparison and about
- Verse page checked specifically for scripture-face regressions

## Not in this PR

Hero imagery (the largest remaining gap against their article pages), the card recipe and coloured-shadow application, container width, and all of dark mode.